### PR TITLE
Add support for emulator options

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -32,6 +32,6 @@ jobs:
         target: google_apis
         arch: x86_64
         profile: Nexus 6
-        headless: true
+        emulator-options: -no-window -no-snapshot -noaudio -no-boot-anim -camera-back emulated
         disable-animations: true
         script: adb devices -l

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ jobs:
 | `target` | Optional | `default` | Target of the system image - `default` or `google_apis`. |
 | `arch` | Optional | `x86` | CPU architecture of the system image - `x86` or `x86_64`. |
 | `profile` | Optional | N/A | Hardware profile used for creating the AVD - e.g. `Nexus 6`. For a list of all profiles available, run `$ANDROID_HOME/tools/bin/avdmanager list` and refer to the results under "Available Android Virtual Devices". |
-| `headless` | Optional | `true` | Whether to launch emulator without UI - `true` or `false`. When set to `true` this is equivalent to running the emulator with `emulator -no-window`. |
+| `emulator-options` | Optional | See below | Command-line options used when launching the emulator (replacing all default options) - e.g. `-no-snapshot -camera-back emulated`. |
 | `disable-animations` | Optional | `true` | Whether to disable animations - `true` or `false`. |
 | `script` | Required | N/A | Custom script to run - e.g. to run Android instrumented tests on the emulator: `./gradlew connectedCheck` |
+
+Default `emulator-options`:
+
+`-no-window -no-snapshot -noaudio -no-boot-anim`

--- a/__tests__/input-validator.test.ts
+++ b/__tests__/input-validator.test.ts
@@ -77,27 +77,6 @@ describe('arch validator tests', () => {
   });
 });
 
-describe('headless validator tests', () => {
-  it('Throws if headless is not a boolean', () => {
-    const func = () => {
-      validator.checkHeadless('yes');
-    };
-    expect(func).toThrowError(`Input for input.headless should be either 'true' or 'false'.`);
-  });
-
-  it('Validates successfully if headless is either true or false', () => {
-    const func1 = () => {
-      validator.checkHeadless('true');
-    };
-    expect(func1).not.toThrow();
-
-    const func2 = () => {
-      validator.checkHeadless('false');
-    };
-    expect(func2).not.toThrow();
-  });
-});
-
 describe('disable-animations validator tests', () => {
   it('Throws if disable-animations is not a boolean', () => {
     const func = () => {

--- a/action.yml
+++ b/action.yml
@@ -16,9 +16,9 @@ inputs:
     default: 'x86'
   profile:
     description: 'Hardware profile used for creating the AVD - e.g. `Nexus 6`.'
-  headless:
-    description: 'whether to launch emulator in without UI - true or false'
-    default: 'true'
+  emulator-options:
+    description: 'command-line options used when launching the emulator - e.g. `-no-snapshot -camera-back emulated`.'
+    default: '-no-window -no-snapshot -noaudio -no-boot-anim'
   disable-animations:
     description: 'whether to disable animations - true or false'
     default: 'true'

--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -22,7 +22,7 @@ const ADB_PATH = `${process.env.ANDROID_HOME}/platform-tools/adb`;
 /**
  * Creates and launches a new AVD instance with the specified configurations.
  */
-function launchEmulator(apiLevel, target, arch, profile, headless, disableAnimations) {
+function launchEmulator(apiLevel, target, arch, profile, emulatorOptions, disableAnimations) {
     return __awaiter(this, void 0, void 0, function* () {
         // create a new AVD
         if (profile.trim() !== '') {
@@ -35,8 +35,15 @@ function launchEmulator(apiLevel, target, arch, profile, headless, disableAnimat
         }
         // start emulator
         console.log('Starting emulator.');
-        const noWindow = headless ? '-no-window' : '';
-        yield exec.exec(`sh -c \\"${process.env.ANDROID_HOME}/emulator/emulator -avd test ${noWindow} -no-snapshot -noaudio -no-boot-anim &"`);
+        yield exec.exec(`sh -c \\"${process.env.ANDROID_HOME}/emulator/emulator -avd test ${emulatorOptions} &"`, [], {
+            listeners: {
+                stderr: (data) => {
+                    if (data.toString().includes('invalid command-line parameter')) {
+                        throw new Error(data.toString());
+                    }
+                }
+            }
+        });
         // wait for emulator to complete booting
         yield waitForDevice();
         yield exec.exec(`${ADB_PATH} shell input keyevent 82`);
@@ -91,7 +98,7 @@ function waitForDevice() {
                 }
             }
             catch (error) {
-                console.error(error.message);
+                console.log(error.message);
             }
             if (attempts < maxAttemps) {
                 yield delay(retryInterval * 1000);

--- a/lib/input-validator.js
+++ b/lib/input-validator.js
@@ -24,12 +24,6 @@ function checkArch(arch) {
     }
 }
 exports.checkArch = checkArch;
-function checkHeadless(headless) {
-    if (headless !== 'true' && headless !== 'false') {
-        throw new Error(`Input for input.headless should be either 'true' or 'false'.`);
-    }
-}
-exports.checkHeadless = checkHeadless;
 function checkDisableAnimations(disableAnimations) {
     if (disableAnimations !== 'true' && disableAnimations !== 'false') {
         throw new Error(`Input for input.disable-animations should be either 'true' or 'false'.`);

--- a/lib/main.js
+++ b/lib/main.js
@@ -43,11 +43,9 @@ function run() {
             // Hardware profile used for creating the AVD
             const profile = core.getInput('profile');
             console.log(`Hardware profile: ${profile}`);
-            // headless mode
-            const headlessInput = core.getInput('headless');
-            input_validator_1.checkHeadless(headlessInput);
-            const headless = headlessInput === 'true';
-            console.log(`headless mode: ${headless}`);
+            // emulator options
+            const emulatorOptions = core.getInput('emulator-options').trim();
+            console.log(`emulator options: ${emulatorOptions}`);
             // disable animations
             const disableAnimationsInput = core.getInput('disable-animations');
             input_validator_1.checkDisableAnimations(disableAnimationsInput);
@@ -55,12 +53,12 @@ function run() {
             console.log(`disable animations: ${disableAnimations}`);
             // custom scrpt to run
             const script = core.getInput('script', { required: true });
-            // install SDK
-            yield sdk_installer_1.installAndroidSdk(apiLevel, target, arch);
-            // launch an emulator
-            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, headless, disableAnimations);
-            // execute the custom script
             try {
+                // install SDK
+                yield sdk_installer_1.installAndroidSdk(apiLevel, target, arch);
+                // launch an emulator
+                yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, emulatorOptions, disableAnimations);
+                // execute the custom script
                 yield exec.exec(`${script}`);
             }
             catch (error) {

--- a/src/input-validator.ts
+++ b/src/input-validator.ts
@@ -23,12 +23,6 @@ export function checkArch(arch: string): void {
   }
 }
 
-export function checkHeadless(headless: string): void {
-  if (headless !== 'true' && headless !== 'false') {
-    throw new Error(`Input for input.headless should be either 'true' or 'false'.`);
-  }
-}
-
 export function checkDisableAnimations(disableAnimations: string): void {
   if (disableAnimations !== 'true' && disableAnimations !== 'false') {
     throw new Error(`Input for input.disable-animations should be either 'true' or 'false'.`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 import { installAndroidSdk } from './sdk-installer';
-import { checkApiLevel, checkTarget, checkArch, checkHeadless, checkDisableAnimations } from './input-validator';
+import { checkApiLevel, checkTarget, checkArch, checkDisableAnimations } from './input-validator';
 import { launchEmulator, killEmulator } from './emulator-manager';
 import * as exec from '@actions/exec';
 
@@ -31,11 +31,9 @@ async function run() {
     const profile = core.getInput('profile');
     console.log(`Hardware profile: ${profile}`);
 
-    // headless mode
-    const headlessInput = core.getInput('headless');
-    checkHeadless(headlessInput);
-    const headless = headlessInput === 'true';
-    console.log(`headless mode: ${headless}`);
+    // emulator options
+    const emulatorOptions = core.getInput('emulator-options').trim();
+    console.log(`emulator options: ${emulatorOptions}`);
 
     // disable animations
     const disableAnimationsInput = core.getInput('disable-animations');
@@ -46,14 +44,14 @@ async function run() {
     // custom scrpt to run
     const script = core.getInput('script', { required: true });
 
-    // install SDK
-    await installAndroidSdk(apiLevel, target, arch);
-
-    // launch an emulator
-    await launchEmulator(apiLevel, target, arch, profile, headless, disableAnimations);
-
-    // execute the custom script
     try {
+      // install SDK
+      await installAndroidSdk(apiLevel, target, arch);
+
+      // launch an emulator
+      await launchEmulator(apiLevel, target, arch, profile, emulatorOptions, disableAnimations);
+
+      // execute the custom script
       await exec.exec(`${script}`);
     } catch (error) {
       core.setFailed(error.message);


### PR DESCRIPTION
- Added `emulator-options` action input for providing command-line options when launching the emulator. Default is `-no-window -no-snapshot -noaudio -no-boot-anim`
- Removed `headless` action input

resolves #6 