### PR TITLE
Add support for specifying a custom name used for creating AVD.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -52,6 +52,7 @@ jobs:
         target: default
         arch: x86
         profile: Nexus 6
+        avd-name: test
         emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
         disable-animations: true
         working-directory: ./test-fixture/

--- a/README.md
+++ b/README.md
@@ -90,10 +90,13 @@ jobs:
 
 |  | **Required** | **Default** | **Description** |
 |----------------------|--------------|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|  | **Required** | **Default** | **Description** |
+|----------------------|--------------|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `api-level` | Required | N/A | API level of the platform system image - e.g. 23 for Android Marshmallow, 29 for Android 10. **Minimum API level supported is 15**. |
 | `target` | Optional | `default` | Target of the system image - `default` or `google_apis`. |
 | `arch` | Optional | `x86` | CPU architecture of the system image - `x86` or `x86_64`. Note that `x86_64` image is only available for API 21+. |
 | `profile` | Optional | N/A | Hardware profile used for creating the AVD - e.g. `Nexus 6`. For a list of all profiles available, run `$ANDROID_HOME/tools/bin/avdmanager list` and refer to the results under "Available Android Virtual Devices". |
+| `avd-name` | Optional | `test` | Custom AVD name used for creating the Android Virtual Device. |
 | `emulator-options` | Optional | See below | Command-line options used when launching the emulator (replacing all default options) - e.g. `-no-window -no-snapshot -camera-back emulated`. |
 | `disable-animations` | Optional | `true` | Whether to disable animations - `true` or `false`. |
 | `emulator-build` | Optional | N/A | Build number of a specific version of the emulator binary to use e.g. `6061023` for emulator v29.3.0.0. |

--- a/action.yml
+++ b/action.yml
@@ -15,17 +15,20 @@ inputs:
     description: 'CPU architecture of the system image - x86 or x86_64'
     default: 'x86'
   profile:
-    description: 'hardware profile used for creating the AVD - e.g. `Nexus 6`.'
+    description: 'hardware profile used for creating the AVD - e.g. `Nexus 6`'
+  avd-name:
+    description: 'custom AVD name used for creating the Android Virtual Device'
+    default: 'test'
   emulator-options:
-    description: 'command-line options used when launching the emulator - e.g. `-no-window -no-snapshot -camera-back emulated`.'
+    description: 'command-line options used when launching the emulator - e.g. `-no-window -no-snapshot -camera-back emulated`'
     default: '-no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim'
   disable-animations:
     description: 'whether to disable animations - true or false'
     default: 'true'
   emulator-build:
-    description: 'build number of a specific version of the emulator binary to use - e.g. `6061023` for emulator v29.3.0.0.'
+    description: 'build number of a specific version of the emulator binary to use - e.g. `6061023` for emulator v29.3.0.0'
   working-directory:
-    description: 'A custom working directory - e.g. `./android` if your root Gradle project is under the `./android` sub-directory within your repository.'
+    description: 'A custom working directory - e.g. `./android` if your root Gradle project is under the `./android` sub-directory within your repository'
   ndk:
     description: 'version of NDK to install - e.g. 21.0.6113669'
   cmake:

--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -20,16 +20,16 @@ const EMULATOR_BOOT_TIMEOUT_SECONDS = 600;
 /**
  * Creates and launches a new AVD instance with the specified configurations.
  */
-function launchEmulator(apiLevel, target, arch, profile, emulatorOptions, disableAnimations) {
+function launchEmulator(apiLevel, target, arch, profile, avdName, emulatorOptions, disableAnimations) {
     return __awaiter(this, void 0, void 0, function* () {
         // create a new AVD
         if (profile.trim() !== '') {
             console.log(`Creating AVD with custom profile ${profile}`);
-            yield exec.exec(`avdmanager create avd --force -n test --abi "${target}/${arch}" --package "system-images;android-${apiLevel};${target};${arch}" --device "${profile}"`);
+            yield exec.exec(`avdmanager create avd --force -n "${avdName}" --abi "${target}/${arch}" --package "system-images;android-${apiLevel};${target};${arch}" --device "${profile}"`);
         }
         else {
             console.log(`Creating AVD without custom profile.`);
-            yield exec.exec(`sh -c \\"echo no | avdmanager create avd --force -n test --abi '${target}/${arch}' --package 'system-images;android-${apiLevel};${target};${arch}'"`);
+            yield exec.exec(`sh -c \\"echo no | avdmanager create avd --force -n "${avdName}" --abi '${target}/${arch}' --package 'system-images;android-${apiLevel};${target};${arch}'"`);
         }
         // start emulator
         console.log('Starting emulator.');
@@ -37,7 +37,7 @@ function launchEmulator(apiLevel, target, arch, profile, emulatorOptions, disabl
         if (process.platform === 'linux') {
             emulatorOptions += ' -accel off';
         }
-        yield exec.exec(`sh -c \\"${process.env.ANDROID_HOME}/emulator/emulator -avd test ${emulatorOptions} &"`, [], {
+        yield exec.exec(`sh -c \\"${process.env.ANDROID_HOME}/emulator/emulator -avd "${avdName}" ${emulatorOptions} &"`, [], {
             listeners: {
                 stderr: (data) => {
                     if (data.toString().includes('invalid command-line parameter')) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -49,6 +49,9 @@ function run() {
             // Hardware profile used for creating the AVD
             const profile = core.getInput('profile');
             console.log(`Hardware profile: ${profile}`);
+            // custom name used for creating the AVD
+            const avdName = core.getInput('avd-name');
+            console.log(`AVD name: ${avdName}`);
             // emulator options
             const emulatorOptions = core.getInput('emulator-options').trim();
             console.log(`emulator options: ${emulatorOptions}`);
@@ -92,7 +95,7 @@ function run() {
             // install SDK
             yield sdk_installer_1.installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
             // launch an emulator
-            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, emulatorOptions, disableAnimations);
+            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, avdName, emulatorOptions, disableAnimations);
             // execute the custom script
             try {
                 // move to custom working directory if set

--- a/src/emulator-manager.ts
+++ b/src/emulator-manager.ts
@@ -5,14 +5,14 @@ const EMULATOR_BOOT_TIMEOUT_SECONDS = 600;
 /**
  * Creates and launches a new AVD instance with the specified configurations.
  */
-export async function launchEmulator(apiLevel: number, target: string, arch: string, profile: string, emulatorOptions: string, disableAnimations: boolean): Promise<void> {
+export async function launchEmulator(apiLevel: number, target: string, arch: string, profile: string, avdName: string, emulatorOptions: string, disableAnimations: boolean): Promise<void> {
   // create a new AVD
   if (profile.trim() !== '') {
     console.log(`Creating AVD with custom profile ${profile}`);
-    await exec.exec(`avdmanager create avd --force -n test --abi "${target}/${arch}" --package "system-images;android-${apiLevel};${target};${arch}" --device "${profile}"`);
+    await exec.exec(`avdmanager create avd --force -n "${avdName}" --abi "${target}/${arch}" --package "system-images;android-${apiLevel};${target};${arch}" --device "${profile}"`);
   } else {
     console.log(`Creating AVD without custom profile.`);
-    await exec.exec(`sh -c \\"echo no | avdmanager create avd --force -n test --abi '${target}/${arch}' --package 'system-images;android-${apiLevel};${target};${arch}'"`);
+    await exec.exec(`sh -c \\"echo no | avdmanager create avd --force -n "${avdName}" --abi '${target}/${arch}' --package 'system-images;android-${apiLevel};${target};${arch}'"`);
   }
 
   // start emulator
@@ -23,7 +23,7 @@ export async function launchEmulator(apiLevel: number, target: string, arch: str
     emulatorOptions += ' -accel off';
   }
 
-  await exec.exec(`sh -c \\"${process.env.ANDROID_HOME}/emulator/emulator -avd test ${emulatorOptions} &"`, [], {
+  await exec.exec(`sh -c \\"${process.env.ANDROID_HOME}/emulator/emulator -avd "${avdName}" ${emulatorOptions} &"`, [], {
     listeners: {
       stderr: (data: Buffer) => {
         if (data.toString().includes('invalid command-line parameter')) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,10 @@ async function run() {
     const profile = core.getInput('profile');
     console.log(`Hardware profile: ${profile}`);
 
+    // custom name used for creating the AVD
+    const avdName = core.getInput('avd-name');
+    console.log(`AVD name: ${avdName}`);
+
     // emulator options
     const emulatorOptions = core.getInput('emulator-options').trim();
     console.log(`emulator options: ${emulatorOptions}`);
@@ -89,7 +93,7 @@ async function run() {
     await installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
 
     // launch an emulator
-    await launchEmulator(apiLevel, target, arch, profile, emulatorOptions, disableAnimations);
+    await launchEmulator(apiLevel, target, arch, profile, avdName, emulatorOptions, disableAnimations);
 
     // execute the custom script
     try {


### PR DESCRIPTION
Resolves #59.

Added an action input `avd-name` for specifying a custom name used for creating the Android Virtual Device.