### PR TITLE
Support API 30

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,11 +15,22 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest]
         api-level: [16, 23, 29]
+        target: [default, google_apis]
         exclude:
           - os: ubuntu-latest
             api-level: 23
           - os: ubuntu-latest
             api-level: 29
+          - target: google_apis
+            api-level: 16
+          - target: google_apis
+            api-level: 23
+          - target: google_apis
+            api-level: 29
+        include:
+          - os: macos-latest
+            api-level: 30
+            target: google_apis
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -49,7 +60,7 @@ jobs:
       uses: ./
       with:
         api-level: ${{ matrix.api-level }}
-        target: default
+        target: ${{ matrix.target }}
         arch: x86
         profile: Nexus 6
         avd-name: test

--- a/lib/sdk-installer.js
+++ b/lib/sdk-installer.js
@@ -17,7 +17,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
 const exec = __importStar(require("@actions/exec"));
-const BUILD_TOOLS_VERSION = '29.0.3';
+const BUILD_TOOLS_VERSION = '30.0.0';
 const CMDLINE_TOOLS_URL_MAC = 'https://dl.google.com/android/repository/commandlinetools-mac-6514223_latest.zip';
 const CMDLINE_TOOLS_URL_LINUX = 'https://dl.google.com/android/repository/commandlinetools-linux-6514223_latest.zip';
 /**
@@ -37,8 +37,12 @@ function installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cm
         core.addPath(`${process.env.ANDROID_HOME}/cmdline-tools/tools:${process.env.ANDROID_HOME}/cmdline-tools/tools/bin:${process.env.ANDROID_HOME}/platform-tools`);
         // additional permission and license requirements for Linux
         if (!isOnMac) {
-            yield exec.exec(`sh -c \\"sudo chmod -R 777 ${process.env.ANDROID_HOME}"`);
+            yield exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME} -R`);
             yield exec.exec(`sh -c \\"echo -e '\n84831b9409646a918e30573bab4c9c91346d8abd' > ${process.env.ANDROID_HOME}/licenses/android-sdk-preview-license"`);
+        }
+        // license required for API 30 system images
+        if (apiLevel == 30) {
+            yield exec.exec(`sh -c \\"echo -e '\n859f317696f67ef3d7f30a50a5560e7834b43903' > ${process.env.ANDROID_HOME}/licenses/android-sdk-arm-dbt-license"`);
         }
         console.log('Installing latest build tools, platform tools, and platform.');
         yield exec.exec(`sh -c \\"sdkmanager --install 'build-tools;${BUILD_TOOLS_VERSION}' platform-tools 'platforms;android-${apiLevel}' > /dev/null"`);

--- a/src/sdk-installer.ts
+++ b/src/sdk-installer.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 
-const BUILD_TOOLS_VERSION = '29.0.3';
+const BUILD_TOOLS_VERSION = '30.0.0';
 const CMDLINE_TOOLS_URL_MAC = 'https://dl.google.com/android/repository/commandlinetools-mac-6514223_latest.zip';
 const CMDLINE_TOOLS_URL_LINUX = 'https://dl.google.com/android/repository/commandlinetools-linux-6514223_latest.zip';
 
@@ -23,8 +23,12 @@ export async function installAndroidSdk(apiLevel: number, target: string, arch: 
 
   // additional permission and license requirements for Linux
   if (!isOnMac) {
-    await exec.exec(`sh -c \\"sudo chmod -R 777 ${process.env.ANDROID_HOME}"`);
+    await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME} -R`);
     await exec.exec(`sh -c \\"echo -e '\n84831b9409646a918e30573bab4c9c91346d8abd' > ${process.env.ANDROID_HOME}/licenses/android-sdk-preview-license"`);
+  }
+  // license required for API 30 system images
+  if (apiLevel == 30) {
+    await exec.exec(`sh -c \\"echo -e '\n859f317696f67ef3d7f30a50a5560e7834b43903' > ${process.env.ANDROID_HOME}/licenses/android-sdk-arm-dbt-license"`);
   }
 
   console.log('Installing latest build tools, platform tools, and platform.');

--- a/test-fixture/app/build.gradle
+++ b/test-fixture/app/build.gradle
@@ -3,13 +3,13 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    compileSdkVersion 30
+    buildToolsVersion "30.0.0"
 
     defaultConfig {
         applicationId "com.example.testapp"
         minSdkVersion 15
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 

--- a/test-fixture/gradle/wrapper/gradle-wrapper.properties
+++ b/test-fixture/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
Resolves #70 

- Update build tools to `30.0.0`
- Add license required for API 30 system images
- Update test project's `targetSdk` and `compileSdk` to `30`

**Currently only `google_apis` system images are available for API 30**.