### PR TITLE
Add suport to self-hosted environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,25 @@ jobs:
         script: ./gradlew connectedCheck
 ```
 
+If you need to run in a self-hosted environment:
+```
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - name: run tests
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 29
+        script: ./gradlew connectedCheck
+        self-hosted: true
+        android-home: ~/android-sdk
+        accept-android-sdk-license: true
+```
+
 ## Configurations
 
 |  | **Required** | **Default** | **Description** |
@@ -100,6 +119,9 @@ jobs:
 | `ndk` | Optional | N/A | Version of NDK to install - e.g. `21.0.6113669` |
 | `cmake` | Optional | N/A | Version of CMake to install - e.g. `3.10.2.4988404` |
 | `script` | Required | N/A | Custom script to run - e.g. to run Android instrumented tests on the emulator: `./gradlew connectedCheck` |
+| `self-hosted` | Optional | `false` | `Run the actions in a self-hosted environment. This option will ignore your current "ANDROID_HOME" installation and install do a fresh install` |
+| `android-home` | Optional | N/A | `Path to ANDROID_HOME, useful in self-hosted environment. If the path does not exists, this action will install the base SDK.` |
+| `accept-android-sdk-license` | Optional | `false` | `Accept Android SDK License. Make sure you read https://developer.android.com/studio/terms and set to true if you accept.` |
 
 Default `emulator-options`: `-no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim`.
 

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,14 @@ inputs:
   script:
     description: 'custom script to run - e.g. `./gradlew connectedCheck`'
     required: true
+  self-hosted:
+    description: 'Run the actions in a self-hosted environment. This option will ignore your current "ANDROID_HOME" installation and install do a fresh install'
+    default: 'false'
+  android-home:
+    description: 'Path to ANDROID_HOME, useful in self-hosted environment. If the path does not exists, this action will install.'
+  accept-android-sdk-license:
+    description: 'Accept Android SDK License. Make sure you read https://developer.android.com/studio/terms and set to true if you accept.'
+    default: 'false'
 runs:
   using: 'node12'
   main: 'lib/main.js'

--- a/lib/main.js
+++ b/lib/main.js
@@ -92,6 +92,21 @@ function run() {
             scripts.forEach((script) => __awaiter(this, void 0, void 0, function* () {
                 console.log(`${script}`);
             }));
+            // android-home
+            const androidHome = core.getInput('android-home');
+            if (androidHome) {
+                core.exportVariable('ANDROID_HOME', `${process.env.HOME}/android-sdk`);
+                core.exportVariable('ANDROID_SDK_ROOT', `${process.env.HOME}/android-sdk`);
+            }
+            else {
+                // If this is a self-hosted environment, and the android-home isn't set,
+                // then use a default path in user's home.
+                const selfHosted = core.getInput('self-hosted');
+                if (selfHosted) {
+                    core.exportVariable('ANDROID_HOME', `${process.env.HOME}/android-sdk`);
+                    core.exportVariable('ANDROID_SDK_ROOT', `${process.env.HOME}/android-sdk`);
+                }
+            }
             // install SDK
             yield sdk_installer_1.installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
             // launch an emulator

--- a/lib/sdk-installer.js
+++ b/lib/sdk-installer.js
@@ -22,6 +22,8 @@ const fs = __importStar(require("fs"));
 const BUILD_TOOLS_VERSION = '30.0.0';
 const CMDLINE_TOOLS_URL_MAC = 'https://dl.google.com/android/repository/commandlinetools-mac-6609375_latest.zip';
 const CMDLINE_TOOLS_URL_LINUX = 'https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip';
+const BASE_ANDROID_SDK_URL_MAC = 'https://dl.google.com/android/repository/sdk-tools-darwin-4333796.zip';
+const BASE_ANDROID_SDK_URL_LINUX = 'https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip';
 /**
  * Installs & updates the Android SDK for the macOS platform, including SDK platform for the chosen API level, latest build tools, platform tools, Android Emulator,
  * and the system image for the chosen API level, CPU arch, and target.
@@ -29,7 +31,31 @@ const CMDLINE_TOOLS_URL_LINUX = 'https://dl.google.com/android/repository/comman
 function installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion) {
     return __awaiter(this, void 0, void 0, function* () {
         const isOnMac = process.platform === 'darwin';
-        if (!isOnMac) {
+        // Check if ANDROID_HOME is set.
+        if (!process.env.ANDROID_HOME) {
+            core.setFailed('ANDROID_HOME is a required environment variable and is not set.\nPlease double check your host settings.');
+            return;
+        }
+        if (fs.existsSync(process.env.ANDROID_HOME)) {
+            console.log('Using previous installation of base Android SDK, found on ${process.env.ANDROID_HOME}');
+        }
+        else {
+            const installed = yield installBaseSdk();
+            if (!installed) {
+                core.setFailed('Could not install base Android SDK.');
+                return;
+            }
+            const licenses = yield acceptLicenses();
+            if (!installed || !licenses) {
+                core.setFailed('Could not accept Android SDK licenses.');
+                return;
+            }
+        }
+        // self-hosted
+        const selfHosted = core.getInput('self-hosted');
+        // It is not required to configure permissions on self-hosted and macos
+        // environment.
+        if (!isOnMac && !selfHosted) {
             yield exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME} -R`);
         }
         const cmdlineToolsPath = `${process.env.ANDROID_HOME}/cmdline-tools`;
@@ -79,3 +105,50 @@ function installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cm
     });
 }
 exports.installAndroidSdk = installAndroidSdk;
+function installBaseSdk() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const isOnMac = process.platform === 'darwin';
+        const baseSdkUrl = isOnMac ? BASE_ANDROID_SDK_URL_MAC : BASE_ANDROID_SDK_URL_LINUX;
+        const androidTmpPath = '/tmp/android-sdk.zip';
+        const androidHome = process.env.ANDROID_HOME;
+        console.log(`Installing Android SDK on ${androidHome}`);
+        // Backup existing .android folder.
+        const sdkHome = `${androidHome}/sdk_home`;
+        core.exportVariable('ANDROID_SDK_HOME', sdkHome);
+        if (fs.existsSync(sdkHome)) {
+            yield exec.exec(`mv ${sdkHome} ${sdkHome}.backup.${Date.now()}`);
+        }
+        yield exec.exec(`curl -L ${baseSdkUrl} -o ${androidTmpPath} -s`);
+        yield exec.exec(`unzip -q ${androidTmpPath} -d ${androidHome}`);
+        yield exec.exec(`rm ${androidTmpPath}`);
+        yield exec.exec(`mkdir -p ${sdkHome}`);
+        const path = process.env.PATH || '';
+        const extraPaths = `${androidHome}/bin:${androidHome}/tools:${androidHome}/tools/bin:${androidHome}/platform-tools:${androidHome}/platform-tools/bin`;
+        // Remove from path any Android previous installation
+        const pathWithoutAndroid = path
+            .split(':')
+            .filter(entry => {
+            return !entry.includes('Android');
+        })
+            .join(':');
+        core.exportVariable('PATH', `${extraPaths}:${pathWithoutAndroid}`);
+        return true;
+    });
+}
+function acceptLicenses() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const androidHome = process.env.ANDROID_HOME;
+        console.log(`Accepting Android SDK licenses on ${androidHome}`);
+        // Check if licenses has being accepted.
+        const acceptLicense = core.getInput('accept-android-sdk-license');
+        if (!acceptLicense) {
+            core.setFailed("You can't use this in self-hosted environment unless you accept the Android SDK licenses. \nPlease read the license https://developer.android.com/studio/terms and accept the license to proceed.");
+            return false;
+        }
+        yield exec.exec(`mkdir -p ${process.env.ANDROID_SDK_HOME}`);
+        yield exec.exec(`touch ${process.env.ANDROID_SDK_HOME}/repositories.cfg`);
+        yield exec.exec(`mkdir -p ${androidHome}/licenses`);
+        yield exec.exec(`sh -c \\"yes 'y' | ${androidHome}/tools/bin/sdkmanager --licenses > /dev/null"`);
+        return true;
+    });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,6 +89,21 @@ async function run() {
       console.log(`${script}`);
     });
 
+    // android-home
+    const androidHome = core.getInput('android-home');
+    if (androidHome) {
+      core.exportVariable('ANDROID_HOME', `${process.env.HOME}/android-sdk`);
+      core.exportVariable('ANDROID_SDK_ROOT', `${process.env.HOME}/android-sdk`);
+    } else {
+      // If this is a self-hosted environment, and the android-home isn't set,
+      // then use a default path in user's home.
+      const selfHosted = core.getInput('self-hosted');
+      if (selfHosted) {
+        core.exportVariable('ANDROID_HOME', `${process.env.HOME}/android-sdk`);
+        core.exportVariable('ANDROID_SDK_ROOT', `${process.env.HOME}/android-sdk`);
+      }
+    }
+
     // install SDK
     await installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
 


### PR DESCRIPTION
Add options to support self hosted environment.

New options are:

* self-hosted: true/false (will ignore path permissions step)
* android-home: path of android sdk (will use if found here or install if not does not exists)
* accept-android-sdk-license: option to user explicit accept android licenses, so script will say yes for all licenses