### PR TITLE
Add support for using google_apis_playstore system images.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,6 +33,10 @@ jobs:
           - os: macos-latest
             api-level: 30
             target: google_apis
+          - os: macos-latest
+            api-level: 24
+            target: playstore
+
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ jobs:
 
 ## Configurations
 
-|  | **Required** | **Default** | **Description** |
-|----------------------|--------------|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Input** | **Required** | **Default** | **Description** |
+|-|-|-|-|
 | `api-level` | Required | N/A | API level of the platform system image - e.g. 23 for Android Marshmallow, 29 for Android 10. **Minimum API level supported is 15**. |
-| `target` | Optional | `default` | Target of the system image - `default` or `google_apis`. |
+| `target` | Optional | `default` | Target of the system image - `default`, `google_apis` or `playstore`. |
 | `arch` | Optional | `x86` | CPU architecture of the system image - `x86` or `x86_64`. Note that `x86_64` image is only available for API 21+. |
 | `profile` | Optional | N/A | Hardware profile used for creating the AVD - e.g. `Nexus 6`. For a list of all profiles available, run `avdmanager list` and refer to the results under "Available Android Virtual Devices". |
 | `avd-name` | Optional | `test` | Custom AVD name used for creating the Android Virtual Device. |

--- a/__tests__/input-validator.test.ts
+++ b/__tests__/input-validator.test.ts
@@ -53,6 +53,11 @@ describe('target validator tests', () => {
       validator.checkTarget('google_apis');
     };
     expect(func2).not.toThrow();
+
+    const func3 = () => {
+      validator.checkTarget('google_apis');
+    };
+    expect(func3).not.toThrow();
   });
 });
 

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'API level of the platform and system image - e.g. 23 for Android Marshmallow, 29 for Android 10'
     required: true
   target:
-    description: 'target of the system image - default or google_apis'
+    description: 'target of the system image - default, google_apis or playstore'
     default: 'default'
   arch:
     description: 'CPU architecture of the system image - x86 or x86_64'

--- a/lib/input-validator.js
+++ b/lib/input-validator.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.checkEmulatorBuild = exports.checkDisableAnimations = exports.checkArch = exports.checkTarget = exports.checkApiLevel = exports.VALID_ARCHS = exports.VALID_TARGETS = exports.MIN_API_LEVEL = void 0;
 exports.MIN_API_LEVEL = 15;
-exports.VALID_TARGETS = ['default', 'google_apis'];
+exports.VALID_TARGETS = ['default', 'google_apis', 'google_apis_playstore'];
 exports.VALID_ARCHS = ['x86', 'x86_64'];
 function checkApiLevel(apiLevel) {
     if (isNaN(Number(apiLevel)) || !Number.isInteger(Number(apiLevel))) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -52,7 +52,8 @@ function run() {
             const apiLevel = Number(apiLevelInput);
             console.log(`API level: ${apiLevel}`);
             // target of the system image
-            const target = core.getInput('target');
+            const targetInput = core.getInput('target');
+            const target = targetInput == 'playstore' ? 'google_apis_playstore' : targetInput;
             input_validator_1.checkTarget(target);
             console.log(`target: ${target}`);
             // CPU architecture of the system image

--- a/src/input-validator.ts
+++ b/src/input-validator.ts
@@ -1,5 +1,5 @@
 export const MIN_API_LEVEL = 15;
-export const VALID_TARGETS: Array<string> = ['default', 'google_apis'];
+export const VALID_TARGETS: Array<string> = ['default', 'google_apis', 'google_apis_playstore'];
 export const VALID_ARCHS: Array<string> = ['x86', 'x86_64'];
 
 export function checkApiLevel(apiLevel: string): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,8 @@ async function run() {
     console.log(`API level: ${apiLevel}`);
 
     // target of the system image
-    const target = core.getInput('target');
+    const targetInput = core.getInput('target');
+    const target = targetInput == 'playstore' ? 'google_apis_playstore' : targetInput;
     checkTarget(target);
     console.log(`target: ${target}`);
 

--- a/test-fixture/gradle.properties
+++ b/test-fixture/gradle.properties
@@ -1,6 +1,7 @@
 org.gradle.parallel=true
 org.gradle.configureondemand=true
 org.gradle.caching=true
+org.gradle.vfs.watch=true
 
 # Enable Kotlin incremental compilation
 kotlin.incremental=true

--- a/test-fixture/gradle/wrapper/gradle-wrapper.properties
+++ b/test-fixture/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip


### PR DESCRIPTION
Resolves #98.

Added a new `playstore` option for `target` to support using system images with the `google_apis_playstore` target:

```
- name: run tests
   uses: reactivecircus/android-emulator-runner@v2
   with:
     api-level: 30
     target: playstore
     arch: x86
     script: ./gradlew connectedCheck
```