### PR TITLE
Add Shopify/android-testify to list of projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,5 +132,6 @@ These are some of the open-source projects using (or used) **Android Emulator Ru
 - [simpledotorg/simple-android](https://github.com/simpledotorg/simple-android)
 - [cashapp/copper](https://github.com/cashapp/copper/blob/trunk/.github/workflows/build.yaml)
 - [square/radiography](https://github.com/square/radiography/blob/main/.github/workflows/android.yml)
+- [Shopify/android-testify](https://github.com/Shopify/android-testify/blob/master/.github/workflows/sample_build.yml)
 
 If you are using **Android Emulator Runner** and want your project included in the list, please feel free to create an issue or open a pull request.


### PR DESCRIPTION
Shopify/android-testify uses the Android Emulator Runner for GitHub Actions