### PR TITLE
Update build tools

### DIFF
--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -51,7 +51,7 @@ function launchEmulator(apiLevel, target, arch, profile, avdName, emulatorOption
         if (process.platform === 'linux') {
             emulatorOptions += ' -accel off';
         }
-        yield exec.exec(`sh -c \\"${process.env.ANDROID_HOME}/emulator/emulator -avd "${avdName}" ${emulatorOptions} &"`, [], {
+        yield exec.exec(`sh -c \\"${process.env.ANDROID_SDK_ROOT}/emulator/emulator -avd "${avdName}" ${emulatorOptions} &"`, [], {
             listeners: {
                 stderr: (data) => {
                     if (data.toString().includes('invalid command-line parameter')) {

--- a/lib/sdk-installer.js
+++ b/lib/sdk-installer.js
@@ -34,7 +34,7 @@ const exec = __importStar(require("@actions/exec"));
 const io = __importStar(require("@actions/io"));
 const tc = __importStar(require("@actions/tool-cache"));
 const fs = __importStar(require("fs"));
-const BUILD_TOOLS_VERSION = '30.0.2';
+const BUILD_TOOLS_VERSION = '30.0.3';
 const CMDLINE_TOOLS_URL_MAC = 'https://dl.google.com/android/repository/commandlinetools-mac-6858069_latest.zip';
 const CMDLINE_TOOLS_URL_LINUX = 'https://dl.google.com/android/repository/commandlinetools-linux-6858069_latest.zip';
 /**
@@ -45,9 +45,9 @@ function installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cm
     return __awaiter(this, void 0, void 0, function* () {
         const isOnMac = process.platform === 'darwin';
         if (!isOnMac) {
-            yield exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME} -R`);
+            yield exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_SDK_ROOT} -R`);
         }
-        const cmdlineToolsPath = `${process.env.ANDROID_HOME}/cmdline-tools`;
+        const cmdlineToolsPath = `${process.env.ANDROID_SDK_ROOT}/cmdline-tools`;
         if (!fs.existsSync(cmdlineToolsPath)) {
             console.log('Installing new cmdline-tools.');
             const sdkUrl = isOnMac ? CMDLINE_TOOLS_URL_MAC : CMDLINE_TOOLS_URL_LINUX;
@@ -55,15 +55,15 @@ function installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cm
             yield tc.extractZip(downloadPath, cmdlineToolsPath);
             yield io.mv(`${cmdlineToolsPath}/cmdline-tools`, `${cmdlineToolsPath}/latest`);
             // add paths for commandline-tools and platform-tools
-            core.addPath(`${cmdlineToolsPath}/latest:${cmdlineToolsPath}/latest/bin:${process.env.ANDROID_HOME}/platform-tools`);
+            core.addPath(`${cmdlineToolsPath}/latest:${cmdlineToolsPath}/latest/bin:${process.env.ANDROID_SDK_ROOT}/platform-tools`);
         }
         // additional permission and license requirements for Linux
-        const sdkPreviewLicensePath = `${process.env.ANDROID_HOME}/licenses/android-sdk-preview-license`;
+        const sdkPreviewLicensePath = `${process.env.ANDROID_SDK_ROOT}/licenses/android-sdk-preview-license`;
         if (!isOnMac && !fs.existsSync(sdkPreviewLicensePath)) {
             fs.writeFileSync(sdkPreviewLicensePath, '\n84831b9409646a918e30573bab4c9c91346d8abd');
         }
         // license required for API 30 system images
-        const sdkArmDbtLicensePath = `${process.env.ANDROID_HOME}/licenses/android-sdk-arm-dbt-license`;
+        const sdkArmDbtLicensePath = `${process.env.ANDROID_SDK_ROOT}/licenses/android-sdk-arm-dbt-license`;
         if (apiLevel == 30 && !fs.existsSync(sdkArmDbtLicensePath)) {
             fs.writeFileSync(sdkArmDbtLicensePath, '\n859f317696f67ef3d7f30a50a5560e7834b43903');
         }
@@ -72,8 +72,8 @@ function installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cm
         if (emulatorBuild) {
             console.log(`Installing emulator build ${emulatorBuild}.`);
             yield exec.exec(`curl -fo emulator.zip https://dl.google.com/android/repository/emulator-${isOnMac ? 'darwin' : 'linux'}-${emulatorBuild}.zip`);
-            yield io.rmRF(`${process.env.ANDROID_HOME}/emulator`);
-            yield exec.exec(`unzip -q emulator.zip -d ${process.env.ANDROID_HOME}`);
+            yield io.rmRF(`${process.env.ANDROID_SDK_ROOT}/emulator`);
+            yield exec.exec(`unzip -q emulator.zip -d ${process.env.ANDROID_SDK_ROOT}`);
             yield io.rmRF('emulator.zip');
         }
         else {

--- a/src/emulator-manager.ts
+++ b/src/emulator-manager.ts
@@ -23,7 +23,7 @@ export async function launchEmulator(apiLevel: number, target: string, arch: str
     emulatorOptions += ' -accel off';
   }
 
-  await exec.exec(`sh -c \\"${process.env.ANDROID_HOME}/emulator/emulator -avd "${avdName}" ${emulatorOptions} &"`, [], {
+  await exec.exec(`sh -c \\"${process.env.ANDROID_SDK_ROOT}/emulator/emulator -avd "${avdName}" ${emulatorOptions} &"`, [], {
     listeners: {
       stderr: (data: Buffer) => {
         if (data.toString().includes('invalid command-line parameter')) {

--- a/src/sdk-installer.ts
+++ b/src/sdk-installer.ts
@@ -4,7 +4,7 @@ import * as io from '@actions/io';
 import * as tc from '@actions/tool-cache';
 import * as fs from 'fs';
 
-const BUILD_TOOLS_VERSION = '30.0.2';
+const BUILD_TOOLS_VERSION = '30.0.3';
 const CMDLINE_TOOLS_URL_MAC = 'https://dl.google.com/android/repository/commandlinetools-mac-6858069_latest.zip';
 const CMDLINE_TOOLS_URL_LINUX = 'https://dl.google.com/android/repository/commandlinetools-linux-6858069_latest.zip';
 
@@ -16,10 +16,10 @@ export async function installAndroidSdk(apiLevel: number, target: string, arch: 
   const isOnMac = process.platform === 'darwin';
 
   if (!isOnMac) {
-    await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME} -R`);
+    await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_SDK_ROOT} -R`);
   }
 
-  const cmdlineToolsPath = `${process.env.ANDROID_HOME}/cmdline-tools`;
+  const cmdlineToolsPath = `${process.env.ANDROID_SDK_ROOT}/cmdline-tools`;
   if (!fs.existsSync(cmdlineToolsPath)) {
     console.log('Installing new cmdline-tools.');
     const sdkUrl = isOnMac ? CMDLINE_TOOLS_URL_MAC : CMDLINE_TOOLS_URL_LINUX;
@@ -27,17 +27,17 @@ export async function installAndroidSdk(apiLevel: number, target: string, arch: 
     await tc.extractZip(downloadPath, cmdlineToolsPath);
     await io.mv(`${cmdlineToolsPath}/cmdline-tools`, `${cmdlineToolsPath}/latest`);
     // add paths for commandline-tools and platform-tools
-    core.addPath(`${cmdlineToolsPath}/latest:${cmdlineToolsPath}/latest/bin:${process.env.ANDROID_HOME}/platform-tools`);
+    core.addPath(`${cmdlineToolsPath}/latest:${cmdlineToolsPath}/latest/bin:${process.env.ANDROID_SDK_ROOT}/platform-tools`);
   }
 
   // additional permission and license requirements for Linux
-  const sdkPreviewLicensePath = `${process.env.ANDROID_HOME}/licenses/android-sdk-preview-license`;
+  const sdkPreviewLicensePath = `${process.env.ANDROID_SDK_ROOT}/licenses/android-sdk-preview-license`;
   if (!isOnMac && !fs.existsSync(sdkPreviewLicensePath)) {
     fs.writeFileSync(sdkPreviewLicensePath, '\n84831b9409646a918e30573bab4c9c91346d8abd');
   }
 
   // license required for API 30 system images
-  const sdkArmDbtLicensePath = `${process.env.ANDROID_HOME}/licenses/android-sdk-arm-dbt-license`;
+  const sdkArmDbtLicensePath = `${process.env.ANDROID_SDK_ROOT}/licenses/android-sdk-arm-dbt-license`;
   if (apiLevel == 30 && !fs.existsSync(sdkArmDbtLicensePath)) {
     fs.writeFileSync(sdkArmDbtLicensePath, '\n859f317696f67ef3d7f30a50a5560e7834b43903');
   }
@@ -48,8 +48,8 @@ export async function installAndroidSdk(apiLevel: number, target: string, arch: 
   if (emulatorBuild) {
     console.log(`Installing emulator build ${emulatorBuild}.`);
     await exec.exec(`curl -fo emulator.zip https://dl.google.com/android/repository/emulator-${isOnMac ? 'darwin' : 'linux'}-${emulatorBuild}.zip`);
-    await io.rmRF(`${process.env.ANDROID_HOME}/emulator`);
-    await exec.exec(`unzip -q emulator.zip -d ${process.env.ANDROID_HOME}`);
+    await io.rmRF(`${process.env.ANDROID_SDK_ROOT}/emulator`);
+    await exec.exec(`unzip -q emulator.zip -d ${process.env.ANDROID_SDK_ROOT}`);
     await io.rmRF('emulator.zip');
   } else {
     console.log('Installing latest emulator.');

--- a/test-fixture/app/build.gradle
+++ b/test-fixture/app/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "com.example.testapp"
@@ -26,11 +26,11 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.3.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     testImplementation 'junit:junit:4.13'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }

--- a/test-fixture/build.gradle
+++ b/test-fixture/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.0'
+    ext.kotlin_version = '1.4.21'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/test-fixture/gradle.properties
+++ b/test-fixture/gradle.properties
@@ -24,17 +24,5 @@ kapt.include.compile.classpath=false
 # Use R8 instead of ProGuard for code shrinking.
 android.enableR8.fullMode=true
 
-# Enable gradle workers
-android.enableGradleWorkers=true
-
 # Enable AndroidX
 android.useAndroidX=true
-
-# Enable rudimentary R class namespacing where each library only contains
-# references to the resources it declares instead of declarations plus all
-# transitive dependency references.
-android.namespacedRClass=true
-
-# Only keep the single relevant constructor for types mentioned in XML files
-# instead of using a parameter wildcard which keeps them all.
-android.useMinimalKeepRules=true

--- a/test-fixture/gradle/wrapper/gradle-wrapper.properties
+++ b/test-fixture/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip


### PR DESCRIPTION
Replace usages of deprecated ANDROID_HOME with ANDROID_ROOT_SDK.
Bump build tools to 30.0.3.
Update test-fixture dependencies.