### PR TITLE
Support non-default API 28 images

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -36,6 +36,9 @@ jobs:
           - os: macos-latest
             api-level: 24
             target: playstore
+          - os: macos-latest
+            api-level: 28
+            target: google_apis
 
     steps:
     - name: checkout

--- a/lib/sdk-installer.js
+++ b/lib/sdk-installer.js
@@ -62,9 +62,9 @@ function installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cm
         if (!isOnMac && !fs.existsSync(sdkPreviewLicensePath)) {
             fs.writeFileSync(sdkPreviewLicensePath, '\n84831b9409646a918e30573bab4c9c91346d8abd');
         }
-        // license required for API 30 system images
+        // license required for API 30 and non-default API 28 system images
         const sdkArmDbtLicensePath = `${process.env.ANDROID_SDK_ROOT}/licenses/android-sdk-arm-dbt-license`;
-        if (apiLevel == 30 && !fs.existsSync(sdkArmDbtLicensePath)) {
+        if (requiresArmDbtLicense(apiLevel, target) && !fs.existsSync(sdkArmDbtLicensePath)) {
             fs.writeFileSync(sdkArmDbtLicensePath, '\n859f317696f67ef3d7f30a50a5560e7834b43903');
         }
         console.log('Installing latest build tools, platform tools, and platform.');
@@ -93,3 +93,6 @@ function installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cm
     });
 }
 exports.installAndroidSdk = installAndroidSdk;
+function requiresArmDbtLicense(apiLevel, target) {
+    return apiLevel === 30 || (apiLevel === 28 && target !== 'default');
+}

--- a/src/sdk-installer.ts
+++ b/src/sdk-installer.ts
@@ -36,9 +36,9 @@ export async function installAndroidSdk(apiLevel: number, target: string, arch: 
     fs.writeFileSync(sdkPreviewLicensePath, '\n84831b9409646a918e30573bab4c9c91346d8abd');
   }
 
-  // license required for API 30 system images
+  // license required for API 30 and non-default API 28 system images
   const sdkArmDbtLicensePath = `${process.env.ANDROID_SDK_ROOT}/licenses/android-sdk-arm-dbt-license`;
-  if (apiLevel == 30 && !fs.existsSync(sdkArmDbtLicensePath)) {
+  if (requiresArmDbtLicense(apiLevel, target) && !fs.existsSync(sdkArmDbtLicensePath)) {
     fs.writeFileSync(sdkArmDbtLicensePath, '\n859f317696f67ef3d7f30a50a5560e7834b43903');
   }
 
@@ -66,4 +66,8 @@ export async function installAndroidSdk(apiLevel: number, target: string, arch: 
     console.log(`Installing CMake ${cmakeVersion}.`);
     await exec.exec(`sh -c \\"sdkmanager --install 'cmake;${cmakeVersion}' > /dev/null"`);
   }
+}
+
+function requiresArmDbtLicense(apiLevel: number, target: string): boolean {
+  return apiLevel === 30 || (apiLevel === 28 && target !== 'default');
 }


### PR DESCRIPTION
`google_apis` and `google_apis_playstore` API 28 system images require the `android-sdk-arm-dbt-license` license file, like API 30 system images. This patch updates the check for `android-sdk-arm-dbt-license` to include API 28 system images. The workflow configuration has also been updated to test API 28.