### PR TITLE
Always add path for cmdline-tools to support macos-11.0.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -30,7 +30,7 @@ jobs:
           - target: google_apis
             api-level: 29
         include:
-          - os: macos-latest
+          - os: macos-11.0
             api-level: 30
             target: google_apis
           - os: macos-latest

--- a/lib/sdk-installer.js
+++ b/lib/sdk-installer.js
@@ -54,9 +54,9 @@ function installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cm
             const downloadPath = yield tc.downloadTool(sdkUrl);
             yield tc.extractZip(downloadPath, cmdlineToolsPath);
             yield io.mv(`${cmdlineToolsPath}/cmdline-tools`, `${cmdlineToolsPath}/latest`);
-            // add paths for commandline-tools and platform-tools
-            core.addPath(`${cmdlineToolsPath}/latest:${cmdlineToolsPath}/latest/bin:${process.env.ANDROID_SDK_ROOT}/platform-tools`);
         }
+        // add paths for commandline-tools and platform-tools
+        core.addPath(`${cmdlineToolsPath}/latest:${cmdlineToolsPath}/latest/bin:${process.env.ANDROID_SDK_ROOT}/platform-tools`);
         // additional permission and license requirements for Linux
         const sdkPreviewLicensePath = `${process.env.ANDROID_SDK_ROOT}/licenses/android-sdk-preview-license`;
         if (!isOnMac && !fs.existsSync(sdkPreviewLicensePath)) {

--- a/src/sdk-installer.ts
+++ b/src/sdk-installer.ts
@@ -26,9 +26,10 @@ export async function installAndroidSdk(apiLevel: number, target: string, arch: 
     const downloadPath = await tc.downloadTool(sdkUrl);
     await tc.extractZip(downloadPath, cmdlineToolsPath);
     await io.mv(`${cmdlineToolsPath}/cmdline-tools`, `${cmdlineToolsPath}/latest`);
-    // add paths for commandline-tools and platform-tools
-    core.addPath(`${cmdlineToolsPath}/latest:${cmdlineToolsPath}/latest/bin:${process.env.ANDROID_SDK_ROOT}/platform-tools`);
   }
+
+  // add paths for commandline-tools and platform-tools
+  core.addPath(`${cmdlineToolsPath}/latest:${cmdlineToolsPath}/latest/bin:${process.env.ANDROID_SDK_ROOT}/platform-tools`);
 
   // additional permission and license requirements for Linux
   const sdkPreviewLicensePath = `${process.env.ANDROID_SDK_ROOT}/licenses/android-sdk-preview-license`;


### PR DESCRIPTION
Fixes #123 