### PR TITLE
Add option to modify the number of cores

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -71,6 +71,7 @@ jobs:
         target: ${{ matrix.target }}
         arch: x86
         profile: Nexus 6
+        cores: 2
         sdcard-path-or-size: 100M
         avd-name: test
         emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ jobs:
 | `target` | Optional | `default` | Target of the system image - `default`, `google_apis` or `playstore`. |
 | `arch` | Optional | `x86` | CPU architecture of the system image - `x86` or `x86_64`. Note that `x86_64` image is only available for API 21+. |
 | `profile` | Optional | N/A | Hardware profile used for creating the AVD - e.g. `Nexus 6`. For a list of all profiles available, run `avdmanager list` and refer to the results under "Available Android Virtual Devices". |
-| `cores` | Optional | N/A | Number of cores to use for the emulator (`hw.cpu.ncore` in config.ini). |
+| `cores` | Optional | 2 | Number of cores to use for the emulator (`hw.cpu.ncore` in config.ini). |
 | `sdcard-path-or-size` | Optional | N/A | Path to the SD card image for this AVD or the size of a new SD card image to create for this AVD, in KB or MB, denoted with K or M. - e.g. `path/to/sdcard`, or `1000M`. |
 | `avd-name` | Optional | `test` | Custom AVD name used for creating the Android Virtual Device. |
 | `emulator-options` | Optional | See below | Command-line options used when launching the emulator (replacing all default options) - e.g. `-no-window -no-snapshot -camera-back emulated`. |

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ jobs:
 | `target` | Optional | `default` | Target of the system image - `default`, `google_apis` or `playstore`. |
 | `arch` | Optional | `x86` | CPU architecture of the system image - `x86` or `x86_64`. Note that `x86_64` image is only available for API 21+. |
 | `profile` | Optional | N/A | Hardware profile used for creating the AVD - e.g. `Nexus 6`. For a list of all profiles available, run `avdmanager list` and refer to the results under "Available Android Virtual Devices". |
+| `cores` | Optional | N/A | Number of cores to use for the emulator (`hw.cpu.ncore` in config.ini). |
 | `sdcard-path-or-size` | Optional | N/A | Path to the SD card image for this AVD or the size of a new SD card image to create for this AVD, in KB or MB, denoted with K or M. - e.g. `path/to/sdcard`, or `1000M`. |
 | `avd-name` | Optional | `test` | Custom AVD name used for creating the Android Virtual Device. |
 | `emulator-options` | Optional | See below | Command-line options used when launching the emulator (replacing all default options) - e.g. `-no-window -no-snapshot -camera-back emulated`. |

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,7 @@ inputs:
     description: 'hardware profile used for creating the AVD - e.g. `Nexus 6`'
   cores:
     description: 'the number of cores to use for the emulator'
+    default: 2
   sdcard-path-or-size:
     description: 'path to the SD card image for this AVD or the size of a new SD card image to create for this AVD, in KB or MB, denoted with K or M. - e.g. `path/to/sdcard`, or `1000M`'
   avd-name:

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,8 @@ inputs:
     default: 'x86'
   profile:
     description: 'hardware profile used for creating the AVD - e.g. `Nexus 6`'
+  cores:
+    description: 'the number of cores to use for the emulator'
   sdcard-path-or-size:
     description: 'path to the SD card image for this AVD or the size of a new SD card image to create for this AVD, in KB or MB, denoted with K or M. - e.g. `path/to/sdcard`, or `1000M`'
   avd-name:

--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -34,13 +34,16 @@ const EMULATOR_BOOT_TIMEOUT_SECONDS = 600;
 /**
  * Creates and launches a new AVD instance with the specified configurations.
  */
-function launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations) {
+function launchEmulator(apiLevel, target, arch, profile, cores, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations) {
     return __awaiter(this, void 0, void 0, function* () {
         // create a new AVD
         const profileOption = profile.trim() !== '' ? `--device '${profile}'` : '';
         const sdcardPathOrSizeOption = sdcardPathOrSize.trim() !== '' ? `--sdcard '${sdcardPathOrSize}'` : '';
         console.log(`Creating AVD.`);
         yield exec.exec(`sh -c \\"echo no | avdmanager create avd --force -n "${avdName}" --abi '${target}/${arch}' --package 'system-images;android-${apiLevel};${target};${arch}' ${profileOption} ${sdcardPathOrSizeOption}"`);
+        if (cores) {
+            yield exec.exec(`sh -c \\"printf 'hw.cpu.ncore=${cores}\n' >> ~/.android/avd/"${avdName}".avd"/config.ini`);
+        }
         // start emulator
         console.log('Starting emulator.');
         // turn off hardware acceleration on Linux

--- a/lib/main.js
+++ b/lib/main.js
@@ -63,6 +63,9 @@ function run() {
             // Hardware profile used for creating the AVD
             const profile = core.getInput('profile');
             console.log(`Hardware profile: ${profile}`);
+            // Number of cores to use for emulator
+            const cores = core.getInput('cores');
+            console.log(`Cores: ${cores}`);
             // SD card path or size used for creating the AVD
             const sdcardPathOrSize = core.getInput('sdcard-path-or-size');
             console.log(`SD card path or size: ${sdcardPathOrSize}`);
@@ -112,7 +115,7 @@ function run() {
             // install SDK
             yield sdk_installer_1.installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
             // launch an emulator
-            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations);
+            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, cores, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations);
             // execute the custom script
             try {
                 // move to custom working directory if set

--- a/src/emulator-manager.ts
+++ b/src/emulator-manager.ts
@@ -10,6 +10,7 @@ export async function launchEmulator(
   target: string,
   arch: string,
   profile: string,
+  cores: string,
   sdcardPathOrSize: string,
   avdName: string,
   emulatorOptions: string,
@@ -22,6 +23,10 @@ export async function launchEmulator(
   await exec.exec(
     `sh -c \\"echo no | avdmanager create avd --force -n "${avdName}" --abi '${target}/${arch}' --package 'system-images;android-${apiLevel};${target};${arch}' ${profileOption} ${sdcardPathOrSizeOption}"`
   );
+
+  if (cores) {
+    await exec.exec(`sh -c \\"printf 'hw.cpu.ncore=${cores}\n' >> ~/.android/avd/"${avdName}".avd"/config.ini`);
+  }
 
   // start emulator
   console.log('Starting emulator.');

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,10 @@ async function run() {
     const profile = core.getInput('profile');
     console.log(`Hardware profile: ${profile}`);
 
+    // Number of cores to use for emulator
+    const cores = core.getInput('cores');
+    console.log(`Cores: ${cores}`);
+
     // SD card path or size used for creating the AVD
     const sdcardPathOrSize = core.getInput('sdcard-path-or-size');
     console.log(`SD card path or size: ${sdcardPathOrSize}`);
@@ -98,7 +102,7 @@ async function run() {
     await installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
 
     // launch an emulator
-    await launchEmulator(apiLevel, target, arch, profile, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations);
+    await launchEmulator(apiLevel, target, arch, profile, cores, sdcardPathOrSize, avdName, emulatorOptions, disableAnimations);
 
     // execute the custom script
     try {


### PR DESCRIPTION
As discussed in https://github.com/ReactiveCircus/android-emulator-runner/issues/126, the emulator being set up by `avdmanager` in the new command-line tools only uses 1 core, which affects the stability of the emulator negatively sometimes.

In our experience, 2 cores seem to be pretty solid with no (or almost no) System UI ANR dialogs being shown on boot.

Appending a new line with a duplicate `hw.cpu.ncore` overrides other lines defining the same property before it.

Please let me know if you'd like me to add this option in `workflow.yml` file as well so that the tests include this option as well. Wasn't sure about updating that.