### PR TITLE
Avoid Wrapping Script Code In Quotes

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -123,8 +123,10 @@ function run() {
                     process.chdir(workingDirectory);
                 }
                 for (const script of scripts) {
-                    yield exec.exec(`sh -c \\"${script}"`);
-                }
+                    // use array form to avoid various quote escaping problems
+                    // caused by exec(`sh -c "${script}"`)
+                    yield exec.exec('sh', ['-c', script]);
+               }
             }
             catch (error) {
                 core.setFailed(error.message);

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,7 +111,9 @@ async function run() {
         process.chdir(workingDirectory);
       }
       for (const script of scripts) {
-        await exec.exec(`sh -c \\"${script}"`);
+        // use array form to avoid various quote escaping problems
+        // caused by exec(`sh -c "${script}"`)
+        await exec.exec('sh', ['-c', script]);
       }
     } catch (error) {
       core.setFailed(error.message);


### PR DESCRIPTION
The exec() command only runs a program with literal argument strings.
It does not know how to do things like expanding environment variables,
or piping/redirection.  Hence the way to get "shell intelligence"
is to use exec() to run the `sh` process with the command line string
as a parameter.

But the method being used to do this was:

    exec.exec(`sh -c \\"${script}"`)

This has problems, because wrapping the script in quotes creates
issues when the script itself contains quotes.  Escaping the string
correctly is a non-trivial problem, which also would create "noise"
in the debug output which would add confusion.

http://mywiki.wooledge.org/BashFAQ/050

The easiest way to work around this here is to use the array form of
exec() to pass exactly two parameters to `sh`.  No manipulation of the
script string is needed with this approach:

    exec.exec("sh", ["-c", script])

There are more cases in the project of `sh -c` usage which should also
be changed, and likely abstracted (shellExec()?)  But this small patch
just fixes the most important case for the user-provided script.

---

Additionally, this removes the escaped backslash (`\\`) from the
start of the executed command.  That was presumably to suppress the
use of aliases:

https://unix.stackexchange.com/questions/524254/why-are-backslashes-included-in-this-shell-script

But because this is invoking a non-interactive shell session, aliases
would not apply.  Hence the extra backslash shouldn't be needed.