### PR TITLE
Add kiwix-android to the list of projects that use android-emulator-runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ These are some of the open-source projects using (or used) **Android Emulator Ru
 - [Shopify/android-testify](https://github.com/Shopify/android-testify/blob/master/.github/workflows/sample_build.yml)
 - [square/leakcanary](https://github.com/square/leakcanary/tree/main/.github/workflows)
 - [hash-checker/hash-checker](https://github.com/hash-checker/hash-checker/tree/master/.github/workflows)
-- [hash-checker/hash-checker-lite](https://github.com/hash-checker/hash-checker-lite/tree/master/.github/workflows)
+- [hash-checker/hash-checker-lite](https://github.com/hash-checker/hash-checker-lite/tree/master/.github/workflows)]
+- [Kiwix/kiwix-android](https://github.com/kiwix/kiwix-android/blob/develop/.github/workflows)
 
 If you are using **Android Emulator Runner** and want your project included in the list, please feel free to create an issue or open a pull request.


### PR DESCRIPTION
Add kiwix-android to the list of projects that use ReactiveCircus/android-emulator-runner