### PR TITLE
Add option to set AVD RAM size.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -103,6 +103,7 @@ jobs:
         arch: x86
         profile: Galaxy Nexus
         cores: 2
+        ram-size: 2048M
         sdcard-path-or-size: 100M
         avd-name: test
         force-avd-creation: false

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ jobs:
 | `arch` | Optional | `x86` | CPU architecture of the system image - `x86`, `x86_64` or `arm64-v8a`. Note that `x86_64` image is only available for API 21+. `arm64-v8a` images require Android 4.2+ and are limited to fewer API levels (e.g. 30). |
 | `profile` | Optional | N/A | Hardware profile used for creating the AVD - e.g. `Nexus 6`. For a list of all profiles available, run `avdmanager list` and refer to the results under "Available Android Virtual Devices". |
 | `cores` | Optional | 2 | Number of cores to use for the emulator (`hw.cpu.ncore` in config.ini). |
+| `ram-size` | Optional | N/A | Size of RAM to use for this AVD, in KB or MB, denoted with K or M. - e.g. `2048M` |
 | `sdcard-path-or-size` | Optional | N/A | Path to the SD card image for this AVD or the size of a new SD card image to create for this AVD, in KB or MB, denoted with K or M. - e.g. `path/to/sdcard`, or `1000M`. |
 | `avd-name` | Optional | `test` | Custom AVD name used for creating the Android Virtual Device. |
 | `force-avd-creation` | Optional | `true` | Whether to force create the AVD by overwriting an existing AVD with the same name as `avd-name` - `true` or `false`. |

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,8 @@ inputs:
   cores:
     description: 'the number of cores to use for the emulator'
     default: 2
+  ram-size:
+    description: 'size of RAM to use for this AVD, in KB or MB, denoted with K or M. - e.g. `2048M`'
   sdcard-path-or-size:
     description: 'path to the SD card image for this AVD or the size of a new SD card image to create for this AVD, in KB or MB, denoted with K or M. - e.g. `path/to/sdcard`, or `1000M`'
   avd-name:

--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -35,7 +35,7 @@ const EMULATOR_BOOT_TIMEOUT_SECONDS = 600;
 /**
  * Creates and launches a new AVD instance with the specified configurations.
  */
-function launchEmulator(apiLevel, target, arch, profile, cores, sdcardPathOrSize, avdName, forceAvdCreation, emulatorOptions, disableAnimations, disableSpellChecker, disableLinuxHardwareAcceleration) {
+function launchEmulator(apiLevel, target, arch, profile, cores, ramSize, sdcardPathOrSize, avdName, forceAvdCreation, emulatorOptions, disableAnimations, disableSpellChecker, disableLinuxHardwareAcceleration) {
     return __awaiter(this, void 0, void 0, function* () {
         // create a new AVD if AVD directory does not already exist or forceAvdCreation is true
         const avdPath = `${process.env.ANDROID_AVD_HOME}/${avdName}.avd`;
@@ -47,6 +47,9 @@ function launchEmulator(apiLevel, target, arch, profile, cores, sdcardPathOrSize
         }
         if (cores) {
             yield exec.exec(`sh -c \\"printf 'hw.cpu.ncore=${cores}\n' >> ${process.env.ANDROID_AVD_HOME}/"${avdName}".avd"/config.ini`);
+        }
+        if (ramSize) {
+            yield exec.exec(`sh -c \\"printf 'hw.ramSize=${ramSize}\n' >> ${process.env.ANDROID_AVD_HOME}/"${avdName}".avd"/config.ini`);
         }
         //turn off hardware acceleration on Linux
         if (process.platform === 'linux' && disableLinuxHardwareAcceleration) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -66,6 +66,9 @@ function run() {
             // Number of cores to use for emulator
             const cores = core.getInput('cores');
             console.log(`Cores: ${cores}`);
+            // RAM to use for AVD
+            const ramSize = core.getInput('ram-size');
+            console.log(`RAM size: ${ramSize}`);
             // SD card path or size used for creating the AVD
             const sdcardPathOrSize = core.getInput('sdcard-path-or-size');
             console.log(`SD card path or size: ${sdcardPathOrSize}`);
@@ -130,7 +133,7 @@ function run() {
             // install SDK
             yield sdk_installer_1.installAndroidSdk(apiLevel, target, arch, emulatorBuild, ndkVersion, cmakeVersion);
             // launch an emulator
-            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, cores, sdcardPathOrSize, avdName, forceAvdCreation, emulatorOptions, disableAnimations, disableSpellchecker, disableLinuxHardwareAcceleration);
+            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, cores, ramSize, sdcardPathOrSize, avdName, forceAvdCreation, emulatorOptions, disableAnimations, disableSpellchecker, disableLinuxHardwareAcceleration);
             // execute the custom script
             try {
                 // move to custom working directory if set

--- a/src/emulator-manager.ts
+++ b/src/emulator-manager.ts
@@ -12,6 +12,7 @@ export async function launchEmulator(
   arch: string,
   profile: string,
   cores: string,
+  ramSize: string,
   sdcardPathOrSize: string,
   avdName: string,
   forceAvdCreation: boolean,
@@ -33,6 +34,10 @@ export async function launchEmulator(
 
   if (cores) {
     await exec.exec(`sh -c \\"printf 'hw.cpu.ncore=${cores}\n' >> ${process.env.ANDROID_AVD_HOME}/"${avdName}".avd"/config.ini`);
+  }
+
+  if (ramSize) {
+    await exec.exec(`sh -c \\"printf 'hw.ramSize=${ramSize}\n' >> ${process.env.ANDROID_AVD_HOME}/"${avdName}".avd"/config.ini`);
   }
 
   //turn off hardware acceleration on Linux

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,6 +52,10 @@ async function run() {
     const cores = core.getInput('cores');
     console.log(`Cores: ${cores}`);
 
+    // RAM to use for AVD
+    const ramSize = core.getInput('ram-size');
+    console.log(`RAM size: ${ramSize}`);
+
     // SD card path or size used for creating the AVD
     const sdcardPathOrSize = core.getInput('sdcard-path-or-size');
     console.log(`SD card path or size: ${sdcardPathOrSize}`);
@@ -135,6 +139,7 @@ async function run() {
       arch,
       profile,
       cores,
+      ramSize,
       sdcardPathOrSize,
       avdName,
       forceAvdCreation,


### PR DESCRIPTION
Resolves #139.

Added `ram-size` option. This is taken from @AfzalivE 's  changes in the [Todoist fork](https://github.com/Doist/android-emulator-runner).