### PR TITLE
168 - Auto-accept license terms from sdkmanager

### DIFF
--- a/src/sdk-installer.ts
+++ b/src/sdk-installer.ts
@@ -62,7 +62,7 @@ export async function installAndroidSdk(apiLevel: number, target: string, arch: 
     await io.rmRF('emulator.zip');
   }
   console.log('Installing system images.');
-  await exec.exec(`sh -c \\"sdkmanager --install 'system-images;android-${apiLevel};${target};${arch}' > /dev/null"`);
+  await exec.exec(`sh -c \\"yes | sdkmanager --install 'system-images;android-${apiLevel};${target};${arch}' > /dev/null"`);
 
   if (ndkVersion) {
     console.log(`Installing NDK ${ndkVersion}.`);


### PR DESCRIPTION
Issue: #168

The sdkmanager is hanging the script while installing SDKs because waits the user to accept the SDK license terms. Removing the `> /dev/null` is clear that is the reason why the CI jobs are failing at this point:

```
$ sdkmanager --install 'system-images;android-29;default;x86'
License android-sdk-preview-license:    ] 10% Computing updates...              
---------------------------------------
To get started with the Android SDK Preview, you must agree to the following terms and conditions. As described below, please note that this is a preview version of the Android SDK, subject to change, that you use at your own risk. The Android SDK Preview is not a stable release, and may contain errors and defects that can result in serious damage to your computer systems, devices and data.

This is the Android SDK Preview License Agreement (the "License Agreement").

1. Introduction

1.1 The Android SDK Previ ...
...
..................... LONG LICENSE TERMS .....................
...

June 2014.
---------------------------------------
Accept? (y/N):
```
