### PR TITLE
Support non-mobile targets (Wear OS, TV)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ jobs:
 | **Input** | **Required** | **Default** | **Description** |
 |-|-|-|-|
 | `api-level` | Required | N/A | API level of the platform system image - e.g. 23 for Android Marshmallow, 29 for Android 10. **Minimum API level supported is 15**. |
-| `target` | Optional | `default` | Target of the system image - `default`, `google_apis` or `playstore`. |
+| `target` | Optional | `default` | Target of the system image - `default`, `google_apis`, `google_apis_playstore`, `android-wear`, `android-wear-cn`, `android-tv` or `google-tv`. |
 | `arch` | Optional | `x86` | CPU architecture of the system image - `x86`, `x86_64` or `arm64-v8a`. Note that `x86_64` image is only available for API 21+. `arm64-v8a` images require Android 4.2+ and are limited to fewer API levels (e.g. 30). |
 | `profile` | Optional | N/A | Hardware profile used for creating the AVD - e.g. `Nexus 6`. For a list of all profiles available, run `avdmanager list` and refer to the results under "Available Android Virtual Devices". |
 | `cores` | Optional | 2 | Number of cores to use for the emulator (`hw.cpu.ncore` in config.ini). |

--- a/__tests__/input-validator.test.ts
+++ b/__tests__/input-validator.test.ts
@@ -55,9 +55,29 @@ describe('target validator tests', () => {
     expect(func2).not.toThrow();
 
     const func3 = () => {
-      validator.checkTarget('google_apis');
+      validator.checkTarget('google_apis_playstore');
     };
     expect(func3).not.toThrow();
+
+    const func4 = () => {
+      validator.checkTarget('android-wear');
+    };
+    expect(func4).not.toThrow();
+
+    const func5 = () => {
+      validator.checkTarget('android-wear-cn');
+    };
+    expect(func5).not.toThrow();
+
+    const func6 = () => {
+      validator.checkTarget('android-tv');
+    };
+    expect(func6).not.toThrow();
+
+    const func7 = () => {
+      validator.checkTarget('google-tv');
+    };
+    expect(func7).not.toThrow();
   });
 });
 

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'API level of the platform and system image - e.g. 23 for Android Marshmallow, 29 for Android 10'
     required: true
   target:
-    description: 'target of the system image - default, google_apis or playstore'
+    description: 'target of the system image - default, google_apis, google_apis_playstore, android-wear, android-wear-cn, android-tv or google-tv'
     default: 'default'
   arch:
     description: 'CPU architecture of the system image - x86, x86_64 or arm64-v8a'

--- a/lib/input-validator.js
+++ b/lib/input-validator.js
@@ -2,7 +2,15 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.checkEmulatorBuild = exports.checkDisableLinuxHardwareAcceleration = exports.checkDisableSpellchecker = exports.checkDisableAnimations = exports.checkForceAvdCreation = exports.checkArch = exports.checkTarget = exports.checkApiLevel = exports.VALID_ARCHS = exports.VALID_TARGETS = exports.MIN_API_LEVEL = void 0;
 exports.MIN_API_LEVEL = 15;
-exports.VALID_TARGETS = ['default', 'google_apis', 'google_apis_playstore'];
+exports.VALID_TARGETS = [
+    'default',
+    'google_apis',
+    'google_apis_playstore',
+    'android-wear',
+    'android-wear-cn',
+    'android-tv',
+    'google-tv'
+];
 exports.VALID_ARCHS = ['x86', 'x86_64', 'arm64-v8a'];
 function checkApiLevel(apiLevel) {
     if (isNaN(Number(apiLevel)) || !Number.isInteger(Number(apiLevel))) {

--- a/src/input-validator.ts
+++ b/src/input-validator.ts
@@ -1,5 +1,5 @@
 export const MIN_API_LEVEL = 15;
-export const VALID_TARGETS: Array<string> = ['default', 'google_apis', 'google_apis_playstore'];
+export const VALID_TARGETS: Array<string> = ['default', 'google_apis', 'google_apis_playstore', 'android-wear', 'android-wear-cn', 'android-tv', 'google-tv'];
 export const VALID_ARCHS: Array<string> = ['x86', 'x86_64', 'arm64-v8a'];
 
 export function checkApiLevel(apiLevel: string): void {


### PR DESCRIPTION
Expands the target allowlist to include `android-wear`, `android-wear-cn`, `android-tv` and `google-tv`, bringing the total number of allowed targets to 7.

This fixes #175 