### PR TITLE
README.md update: wikimedia have likely renamed master -> main

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ These are some of the open-source projects using (or used) **Android Emulator Ru
 - [hash-checker/hash-checker](https://github.com/hash-checker/hash-checker/tree/master/.github/workflows)
 - [hash-checker/hash-checker-lite](https://github.com/hash-checker/hash-checker-lite/tree/master/.github/workflows)
 - [Kiwix/kiwix-android](https://github.com/kiwix/kiwix-android/blob/develop/.github/workflows)
-- [wikimedia/apps-android-wikipedia](https://github.com/wikimedia/apps-android-wikipedia/blob/master/.github/workflows)
+- [wikimedia/apps-android-wikipedia](https://github.com/wikimedia/apps-android-wikipedia/blob/main/.github/workflows)
 - [google/android-fhir](https://github.com/google/android-fhir/tree/master/.github/workflows)
 - [google/accompanist](https://github.com/google/accompanist/blob/main/.github/workflows)
 - [dotanuki-labs/norris](https://github.com/dotanuki-labs/norris/blob/master/.github/workflows/main.yml)


### PR DESCRIPTION
https://github.com/wikimedia/apps-android-wikipedia/tree/master/.github/workflows 404's
https://github.com/wikimedia/apps-android-wikipedia/tree/master seems to be 9000 commits behind main
https://github.com/wikimedia/apps-android-wikipedia/blob/main/.github/workflows/android_smoke_test.yml (for example) references this action still

I think it wants to point to main instead?