### PR TITLE
Add API 32 regression on macos-11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,10 @@ jobs:
             api-level: 31
             target: google_apis
             arch: x86_64
+          - os: macos-11
+            api-level: 32
+            target: google_apis
+            arch: x86_64
 
     steps:
     - name: checkout


### PR DESCRIPTION
I have used `android-emulator-runner` for API 32 google_apis image on macos-11 on GitHub Action, and it worked greatly. This PR adds API 32 regression for it on CI, and let other folks know `android-emulator-runner` supports API 32 now.