### PR TITLE
Add option to specify AVD heap size

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ jobs:
 | `profile` | Optional | N/A | Hardware profile used for creating the AVD - e.g. `Nexus 6`. For a list of all profiles available, run `avdmanager list device`. |
 | `cores` | Optional | 2 | Number of cores to use for the emulator (`hw.cpu.ncore` in config.ini). |
 | `ram-size` | Optional | N/A | Size of RAM to use for this AVD, in KB or MB, denoted with K or M. - e.g. `2048M` |
+| `heap-size` | Optional | N/A | Heap size to use for this AVD, in KB or MB, denoted with K or M. - e.g. `512M` |
 | `sdcard-path-or-size` | Optional | N/A | Path to the SD card image for this AVD or the size of a new SD card image to create for this AVD, in KB or MB, denoted with K or M. - e.g. `path/to/sdcard`, or `1000M`. |
 | `disk-size` | Optional | N/A | Disk size to use for this AVD. Either in bytes or KB, MB or GB, when denoted with K, M or G. - e.g. `2048M` |
 | `avd-name` | Optional | `test` | Custom AVD name used for creating the Android Virtual Device. |

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
   ram-size:
     description: 'size of RAM to use for this AVD, in KB or MB, denoted with K or M. - e.g. `2048M`'
   heap-size:
-    description: 'size of RAM to use for this AVD in MB. - e.g. `512M`'
+    description: 'size of heap to use for this AVD in MB. - e.g. `512M`'
   sdcard-path-or-size:
     description: 'path to the SD card image for this AVD or the size of a new SD card image to create for this AVD, in KB or MB, denoted with K or M. - e.g. `path/to/sdcard`, or `1000M`'
   disk-size:

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,8 @@ inputs:
     default: 2
   ram-size:
     description: 'size of RAM to use for this AVD, in KB or MB, denoted with K or M. - e.g. `2048M`'
+  heap-size:
+    description: 'size of RAM to use for this AVD in MB. - e.g. `512M`'
   sdcard-path-or-size:
     description: 'path to the SD card image for this AVD or the size of a new SD card image to create for this AVD, in KB or MB, denoted with K or M. - e.g. `path/to/sdcard`, or `1000M`'
   disk-size:

--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -35,7 +35,7 @@ const EMULATOR_BOOT_TIMEOUT_SECONDS = 600;
 /**
  * Creates and launches a new AVD instance with the specified configurations.
  */
-function launchEmulator(apiLevel, target, arch, profile, cores, ramSize, sdcardPathOrSize, diskSize, avdName, forceAvdCreation, emulatorOptions, disableAnimations, disableSpellChecker, disableLinuxHardwareAcceleration, enableHardwareKeyboard) {
+function launchEmulator(apiLevel, target, arch, profile, cores, ramSize, heapSize, sdcardPathOrSize, diskSize, avdName, forceAvdCreation, emulatorOptions, disableAnimations, disableSpellChecker, disableLinuxHardwareAcceleration, enableHardwareKeyboard) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             console.log(`::group::Launch Emulator`);
@@ -52,6 +52,9 @@ function launchEmulator(apiLevel, target, arch, profile, cores, ramSize, sdcardP
             }
             if (ramSize) {
                 yield exec.exec(`sh -c \\"printf 'hw.ramSize=${ramSize}\n' >> ${process.env.ANDROID_AVD_HOME}/"${avdName}".avd"/config.ini`);
+            }
+            if (heapSize) {
+                yield exec.exec(`sh -c \\"printf 'hw.heapSize=${heapSize}\n' >> ${process.env.ANDROID_AVD_HOME}/"${avdName}".avd"/config.ini`);
             }
             if (enableHardwareKeyboard) {
                 yield exec.exec(`sh -c \\"printf 'hw.keyboard=yes\n' >> ${process.env.ANDROID_AVD_HOME}/"${avdName}".avd"/config.ini`);

--- a/lib/main.js
+++ b/lib/main.js
@@ -71,6 +71,9 @@ function run() {
             // RAM to use for AVD
             const ramSize = core.getInput('ram-size');
             console.log(`RAM size: ${ramSize}`);
+            // Heap size to use for AVD
+            const heapSize = core.getInput('heap-size');
+            console.log(`Heap size: ${heapSize}`);
             // SD card path or size used for creating the AVD
             const sdcardPathOrSize = core.getInput('sdcard-path-or-size');
             console.log(`SD card path or size: ${sdcardPathOrSize}`);
@@ -149,7 +152,7 @@ function run() {
             // install SDK
             yield sdk_installer_1.installAndroidSdk(apiLevel, target, arch, channelId, emulatorBuild, ndkVersion, cmakeVersion);
             // launch an emulator
-            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, cores, ramSize, sdcardPathOrSize, diskSize, avdName, forceAvdCreation, emulatorOptions, disableAnimations, disableSpellchecker, disableLinuxHardwareAcceleration, enableHardwareKeyboard);
+            yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, cores, ramSize, heapSize, sdcardPathOrSize, diskSize, avdName, forceAvdCreation, emulatorOptions, disableAnimations, disableSpellchecker, disableLinuxHardwareAcceleration, enableHardwareKeyboard);
             // execute the custom script
             try {
                 // move to custom working directory if set

--- a/src/emulator-manager.ts
+++ b/src/emulator-manager.ts
@@ -13,6 +13,7 @@ export async function launchEmulator(
   profile: string,
   cores: string,
   ramSize: string,
+  heapSize: string,
   sdcardPathOrSize: string,
   diskSize: string,
   avdName: string,
@@ -42,6 +43,10 @@ export async function launchEmulator(
 
     if (ramSize) {
       await exec.exec(`sh -c \\"printf 'hw.ramSize=${ramSize}\n' >> ${process.env.ANDROID_AVD_HOME}/"${avdName}".avd"/config.ini`);
+    }
+
+    if (heapSize) {
+      await exec.exec(`sh -c \\"printf 'hw.heapSize=${heapSize}\n' >> ${process.env.ANDROID_AVD_HOME}/"${avdName}".avd"/config.ini`);
     }
 
     if (enableHardwareKeyboard) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,6 +61,10 @@ async function run() {
     const ramSize = core.getInput('ram-size');
     console.log(`RAM size: ${ramSize}`);
 
+    // Heap size to use for AVD
+    const heapSize = core.getInput('heap-size');
+    console.log(`Heap size: ${heapSize}`);
+
     // SD card path or size used for creating the AVD
     const sdcardPathOrSize = core.getInput('sdcard-path-or-size');
     console.log(`SD card path or size: ${sdcardPathOrSize}`);
@@ -162,6 +166,7 @@ async function run() {
       profile,
       cores,
       ramSize,
+      heapSize,
       sdcardPathOrSize,
       diskSize,
       avdName,


### PR DESCRIPTION
This change allows a user to specify the AVD heap size - all pretty much the same as setting RAM size.

Resolves #188 