### PR TITLE
Pre Emulator Launch Script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,6 +114,7 @@ jobs:
         disable-animations: true
         working-directory: ./test-fixture/
         channel: canary
+        pre-emulator-launch-script: echo "Running pre emulator launch script."
         script: |
           echo $GITHUB_REPOSITORY
           adb devices

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,9 @@ jobs:
         disable-animations: true
         working-directory: ./test-fixture/
         channel: canary
-        pre-emulator-launch-script: echo "Running pre emulator launch script."
+        pre-emulator-launch-script: |
+          echo "Running pre emulator launch script. Printing the working directory now:"
+          pwd
         script: |
           echo $GITHUB_REPOSITORY
           adb devices

--- a/README.md
+++ b/README.md
@@ -155,11 +155,12 @@ jobs:
 | `disable-linux-hw-accel` | Optional | `true` | Whether to disable hardware acceleration on Linux machines - `true` or `false`. Note that this is true by default as Github-hosted Linux runners do not support hardware acceleration. |
 | `enable-hw-keyboard` | Optional | `false` | Whether to enable hardware keyboard - `true` or `false`. |
 | `emulator-build` | Optional | N/A | Build number of a specific version of the emulator binary to use e.g. `6061023` for emulator v29.3.0.0. |
-| `working-directory` | Optional | `./` | A custom working directory - e.g. `./android` if your root Gradle project is under the `./android` sub-directory within your repository. |
+| `working-directory` | Optional | `./` | A custom working directory - e.g. `./android` if your root Gradle project is under the `./android` sub-directory within your repository. Will be used for `script` & `pre-emulator-launch-script`. |
 | `ndk` | Optional | N/A | Version of NDK to install - e.g. `21.0.6113669` |
 | `cmake` | Optional | N/A | Version of CMake to install - e.g. `3.10.2.4988404` |
 | `channel` | Optional | stable | Channel to download the SDK components from - `stable`, `beta`, `dev`, `canary` |
 | `script` | Required | N/A | Custom script to run - e.g. to run Android instrumented tests on the emulator: `./gradlew connectedCheck` |
+| `pre-emulator-launch-script` | Optional | N/A | Custom script to run which will run before launch the emulator - e.g. `./adjust-emulator-configs.sh` |
 
 Default `emulator-options`: `-no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim`.
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ jobs:
 | `cmake` | Optional | N/A | Version of CMake to install - e.g. `3.10.2.4988404` |
 | `channel` | Optional | stable | Channel to download the SDK components from - `stable`, `beta`, `dev`, `canary` |
 | `script` | Required | N/A | Custom script to run - e.g. to run Android instrumented tests on the emulator: `./gradlew connectedCheck` |
-| `pre-emulator-launch-script` | Optional | N/A | Custom script to run which will run before launch the emulator - e.g. `./adjust-emulator-configs.sh` |
+| `pre-emulator-launch-script` | Optional | N/A | Custom script to run after creating the AVD and before launching the emulator - e.g. `./adjust-emulator-configs.sh` |
 
 Default `emulator-options`: `-no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim`.
 

--- a/action-types.yml
+++ b/action-types.yml
@@ -62,3 +62,5 @@ inputs:
     - canary
   script:
    type: string
+  pre-emulator-launch-script:
+   type: string

--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,8 @@ inputs:
   script:
     description: 'custom script to run - e.g. `./gradlew connectedCheck`'
     required: true
+  pre-emulator-launch-script:
+    description: 'custom script to run which will run before launch the emulator - e.g. `./adjust-emulator-configs.sh`'
 runs:
   using: 'node12'
   main: 'lib/main.js'

--- a/lib/main.js
+++ b/lib/main.js
@@ -158,8 +158,9 @@ function run() {
             console.log(`::endgroup::`);
             // install SDK
             yield sdk_installer_1.installAndroidSdk(apiLevel, target, arch, channelId, emulatorBuild, ndkVersion, cmakeVersion);
-            // execute pre emulator launch script
+            // execute pre emulator launch script if set
             if (preEmulatorLaunchScripts !== undefined) {
+                console.log(`::group::Run pre emulator launch script`);
                 try {
                     for (const preEmulatorLaunchScript of preEmulatorLaunchScripts) {
                         // use array form to avoid various quote escaping problems
@@ -172,6 +173,7 @@ function run() {
                 catch (error) {
                     core.setFailed(error.message);
                 }
+                console.log(`::endgroup::`);
             }
             // launch an emulator
             yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, cores, ramSize, heapSize, sdcardPathOrSize, diskSize, avdName, forceAvdCreation, emulatorOptions, disableAnimations, disableSpellchecker, disableLinuxHardwareAcceleration, enableHardwareKeyboard);

--- a/lib/main.js
+++ b/lib/main.js
@@ -148,9 +148,39 @@ function run() {
             scripts.forEach((script) => __awaiter(this, void 0, void 0, function* () {
                 console.log(`${script}`);
             }));
+            // custom pre emulator launch script
+            const preEmulatorLaunchScriptInput = core.getInput('pre-emulator-launch-script');
+            const preEmulatorLaunchScripts = !preEmulatorLaunchScriptInput ? undefined : script_parser_1.parseScript(preEmulatorLaunchScriptInput);
+            console.log(`Pre emulator launch script:`);
+            preEmulatorLaunchScripts === null || preEmulatorLaunchScripts === void 0 ? void 0 : preEmulatorLaunchScripts.forEach((script) => __awaiter(this, void 0, void 0, function* () {
+                console.log(`${script}`);
+            }));
             console.log(`::endgroup::`);
             // install SDK
             yield sdk_installer_1.installAndroidSdk(apiLevel, target, arch, channelId, emulatorBuild, ndkVersion, cmakeVersion);
+            // execute pre emulator launch script
+            if (preEmulatorLaunchScripts !== undefined) {
+                try {
+                    // move to custom working directory if set
+                    if (workingDirectory) {
+                        exec.exec('sh', ['pushd', workingDirectory]);
+                    }
+                    for (const preEmulatorLaunchScript of preEmulatorLaunchScripts) {
+                        // use array form to avoid various quote escaping problems
+                        // caused by exec(`sh -c "${preEmulatorLaunchScript}"`)
+                        yield exec.exec('sh', ['-c', preEmulatorLaunchScript]);
+                    }
+                }
+                catch (error) {
+                    core.setFailed(error.message);
+                }
+                finally {
+                    if (workingDirectory) {
+                        // revert changing path to working directory
+                        exec.exec('sh', ['popd']);
+                    }
+                }
+            }
             // launch an emulator
             yield emulator_manager_1.launchEmulator(apiLevel, target, arch, profile, cores, ramSize, heapSize, sdcardPathOrSize, diskSize, avdName, forceAvdCreation, emulatorOptions, disableAnimations, disableSpellchecker, disableLinuxHardwareAcceleration, enableHardwareKeyboard);
             // execute the custom script

--- a/lib/main.js
+++ b/lib/main.js
@@ -161,24 +161,16 @@ function run() {
             // execute pre emulator launch script
             if (preEmulatorLaunchScripts !== undefined) {
                 try {
-                    // move to custom working directory if set
-                    if (workingDirectory) {
-                        exec.exec('sh', ['pushd', workingDirectory]);
-                    }
                     for (const preEmulatorLaunchScript of preEmulatorLaunchScripts) {
                         // use array form to avoid various quote escaping problems
                         // caused by exec(`sh -c "${preEmulatorLaunchScript}"`)
-                        yield exec.exec('sh', ['-c', preEmulatorLaunchScript]);
+                        yield exec.exec('sh', ['-c', preEmulatorLaunchScript], {
+                            cwd: workingDirectory
+                        });
                     }
                 }
                 catch (error) {
                     core.setFailed(error.message);
-                }
-                finally {
-                    if (workingDirectory) {
-                        // revert changing path to working directory
-                        exec.exec('sh', ['popd']);
-                    }
                 }
             }
             // launch an emulator

--- a/src/main.ts
+++ b/src/main.ts
@@ -166,8 +166,9 @@ async function run() {
     // install SDK
     await installAndroidSdk(apiLevel, target, arch, channelId, emulatorBuild, ndkVersion, cmakeVersion);
 
-    // execute pre emulator launch script
+    // execute pre emulator launch script if set
     if (preEmulatorLaunchScripts !== undefined) {
+      console.log(`::group::Run pre emulator launch script`);
       try {
         for (const preEmulatorLaunchScript of preEmulatorLaunchScripts) {
           // use array form to avoid various quote escaping problems
@@ -179,6 +180,7 @@ async function run() {
       } catch (error) {
         core.setFailed(error.message);
       }
+      console.log(`::endgroup::`);
     }
 
     // launch an emulator

--- a/src/main.ts
+++ b/src/main.ts
@@ -169,22 +169,15 @@ async function run() {
     // execute pre emulator launch script
     if (preEmulatorLaunchScripts !== undefined) {
       try {
-        // move to custom working directory if set
-        if (workingDirectory) {
-          exec.exec('sh', ['pushd', workingDirectory]);
-        }
         for (const preEmulatorLaunchScript of preEmulatorLaunchScripts) {
           // use array form to avoid various quote escaping problems
           // caused by exec(`sh -c "${preEmulatorLaunchScript}"`)
-          await exec.exec('sh', ['-c', preEmulatorLaunchScript]);
+          await exec.exec('sh', ['-c', preEmulatorLaunchScript], {
+            cwd: workingDirectory
+          });
         }
       } catch (error) {
         core.setFailed(error.message);
-      } finally {
-        if (workingDirectory) {
-          // revert changing path to working directory
-          exec.exec('sh', ['popd']);
-        }
       }
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -171,7 +171,7 @@ async function run() {
       try {
         // move to custom working directory if set
         if (workingDirectory) {
-          process.chdir(workingDirectory);
+          exec.exec('sh', ['pushd', workingDirectory]);
         }
         for (const preEmulatorLaunchScript of preEmulatorLaunchScripts) {
           // use array form to avoid various quote escaping problems
@@ -180,6 +180,11 @@ async function run() {
         }
       } catch (error) {
         core.setFailed(error.message);
+      } finally {
+        if (workingDirectory) {
+          // revert changing path to working directory
+          exec.exec('sh', ['popd']);
+        }
       }
     }
 


### PR DESCRIPTION
## Description
I added a new parameter `pre-emulator-launcher-script` (if you have better names, please let me know). With this parameter, you can pass a custom script which will be executed before launching the emulator (see #246 for more context).

## Tests
I haven't written any unit tests, but added the `pre-emulator-launcher-script` to the CI of 1 job, so that we have 1 job with the parameter and 1 without the parameter. You can see here the ouput: https://github.com/nilsreichardt/android-emulator-runner/runs/6196378411?check_suite_focus=true#step:9:97

## Related Tickets
Closes #246