### PR TITLE
Add action types

### DIFF
--- a/.github/workflows/action-types.yml
+++ b/.github/workflows/action-types.yml
@@ -1,0 +1,13 @@
+name: Validate action typings
+
+on:
+  push: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  validate-typings:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: krzema12/github-actions-typing@v0

--- a/.github/workflows/action-types.yml
+++ b/.github/workflows/action-types.yml
@@ -1,7 +1,7 @@
 name: Validate action typings
 
 on:
-  push: [main]
+  push:
   pull_request:
   workflow_dispatch:
 

--- a/action-types.yml
+++ b/action-types.yml
@@ -22,7 +22,7 @@ inputs:
   profile:
    type: string
   cores:
-   type: int
+   type: integer
   ram-size:
    type: string
   heap-size:

--- a/action-types.yml
+++ b/action-types.yml
@@ -1,0 +1,64 @@
+inputs:
+  api-level:
+    type: integer
+  target:
+    type: enum
+    allowed-values:
+      - default
+      - google_apis
+      - google_apis_playstore
+      - aosp_atd
+      - google_atd
+      - android-wear
+      - android-wear-cn
+      - android-tv
+      - google-tv
+  arch:
+    type: enum
+    allowed-values:
+     - x86
+     - x86_64
+     - arm64-v8a
+  profile:
+   type: string
+  cores:
+   type: int
+  ram-size:
+   type: string
+  heap-size:
+   type: string
+  sdcard-path-or-size:
+   type: string
+  disk-size:
+   type: string
+  avd-name:
+   type: string
+  force-avd-creation:
+   type: boolean
+  emulator-options:
+   type: string
+  disable-animations:
+   type: boolean
+  disable-spellchecker:
+   type: boolean
+  disable-linux-hw-accel:
+   type: string
+  enable-hw-keyboard:
+   type: boolean
+  emulator-build:
+   type: string
+  working-directory:
+   type: string
+  ndk:
+   type: string
+  cmake:
+   type: string
+  channel:
+   type: enum
+   allowed-values:
+    - stable
+    - beta
+    - dev
+    - canary
+  script:
+   type: string


### PR DESCRIPTION
Github Actions YAML usually isn't as useful as it could be.

https://github.com/krzema12/github-actions-typing

This project setup a way to define types for github actions inputs to build a type-safe DSL.

This commit implements both the typing for this action and the workflow to verify it.