### PR TITLE
docs: add code snipped to enable kvm group permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,15 @@ Default `emulator-options`: `-no-window -gpu swiftshader_indirect -no-snapshot -
 
 The short answer is yes but on Github-hosted Linux runners it's expected to be a much worse experience (on some newer API levels it might not work at all) than running it on macOS, because of the current lack of hardware acceleration support. You can get it running much faster on self-hosted Linux runners but only if the underlying instances support KVM (which most don't). Things might be better on the newer Larger runners but they are still in Beta. It is possible to use this Action with hardware accelerated Linux VMs hosted by a third-party runner provider.
 
-For a longer answer please refer to [this issue](https://github.com/ReactiveCircus/android-emulator-runner/issues/46).
+When using Githubs Larger runners, Actions users will need to add the runner user to the KVM user group:
+```
+- name: Enable KVM group perms
+        run: |
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger --name-match=kvm
+```
+You will then be able to make use of hardware acceleration.
 
 ## Who is using Android Emulator Runner?
 


### PR DESCRIPTION
[Hardware accelerated Android virtualization on Actions Linux larger hosted runners](https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/)
