### PR TITLE
Add emulator-boot-timeout parameter

### DIFF
--- a/action-types.yml
+++ b/action-types.yml
@@ -35,6 +35,8 @@ inputs:
    type: string
   force-avd-creation:
    type: boolean
+  emulator-boot-timeout:
+   type: integer
   emulator-options:
    type: string
   disable-animations:

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ inputs:
   force-avd-creation:
     description: 'whether to force create the AVD by overwriting an existing AVD with the same name as `avd-name` - `true` or `false`'
     default: 'true'
+  emulator-boot-timeout:
+    description: 'Emulator boot timeout in seconds. If it takes longer to boot, the action would fail'
+    default: '600'
   emulator-options:
     description: 'command-line options used when launching the emulator - e.g. `-no-window -no-snapshot -camera-back emulated`'
     default: '-no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim'

--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -35,11 +35,10 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.killEmulator = exports.launchEmulator = void 0;
 const exec = __importStar(require("@actions/exec"));
 const fs = __importStar(require("fs"));
-const EMULATOR_BOOT_TIMEOUT_SECONDS = 600;
 /**
  * Creates and launches a new AVD instance with the specified configurations.
  */
-function launchEmulator(apiLevel, target, arch, profile, cores, ramSize, heapSize, sdcardPathOrSize, diskSize, avdName, forceAvdCreation, emulatorOptions, disableAnimations, disableSpellChecker, disableLinuxHardwareAcceleration, enableHardwareKeyboard) {
+function launchEmulator(apiLevel, target, arch, profile, cores, ramSize, heapSize, sdcardPathOrSize, diskSize, avdName, forceAvdCreation, emulatorBootTimeout, emulatorOptions, disableAnimations, disableSpellChecker, disableLinuxHardwareAcceleration, enableHardwareKeyboard) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             console.log(`::group::Launch Emulator`);
@@ -83,7 +82,7 @@ function launchEmulator(apiLevel, target, arch, profile, cores, ramSize, heapSiz
                 },
             });
             // wait for emulator to complete booting
-            yield waitForDevice();
+            yield waitForDevice(emulatorBootTimeout);
             yield exec.exec(`adb shell input keyevent 82`);
             if (disableAnimations) {
                 console.log('Disabling animations.');
@@ -125,12 +124,12 @@ exports.killEmulator = killEmulator;
 /**
  * Wait for emulator to boot.
  */
-function waitForDevice() {
+function waitForDevice(emulatorBootTimeout) {
     return __awaiter(this, void 0, void 0, function* () {
         let booted = false;
         let attempts = 0;
         const retryInterval = 2; // retry every 2 seconds
-        const maxAttempts = EMULATOR_BOOT_TIMEOUT_SECONDS / 2;
+        const maxAttempts = emulatorBootTimeout / 2;
         while (!booted) {
             try {
                 let result = '';

--- a/lib/main.js
+++ b/lib/main.js
@@ -99,6 +99,9 @@ function run() {
             (0, input_validator_1.checkForceAvdCreation)(forceAvdCreationInput);
             const forceAvdCreation = forceAvdCreationInput === 'true';
             console.log(`force avd creation: ${forceAvdCreation}`);
+            // Emulator boot timeout seconds
+            const emulatorBootTimeout = parseInt(core.getInput('emulator-boot-timeout'), 10);
+            console.log(`Emulator boot timeout: ${emulatorBootTimeout}`);
             // emulator options
             const emulatorOptions = core.getInput('emulator-options').trim();
             console.log(`emulator options: ${emulatorOptions}`);
@@ -190,7 +193,7 @@ function run() {
                 console.log(`::endgroup::`);
             }
             // launch an emulator
-            yield (0, emulator_manager_1.launchEmulator)(apiLevel, target, arch, profile, cores, ramSize, heapSize, sdcardPathOrSize, diskSize, avdName, forceAvdCreation, emulatorOptions, disableAnimations, disableSpellchecker, disableLinuxHardwareAcceleration, enableHardwareKeyboard);
+            yield (0, emulator_manager_1.launchEmulator)(apiLevel, target, arch, profile, cores, ramSize, heapSize, sdcardPathOrSize, diskSize, avdName, forceAvdCreation, emulatorBootTimeout, emulatorOptions, disableAnimations, disableSpellchecker, disableLinuxHardwareAcceleration, enableHardwareKeyboard);
             // execute the custom script
             try {
                 // move to custom working directory if set

--- a/src/emulator-manager.ts
+++ b/src/emulator-manager.ts
@@ -1,8 +1,6 @@
 import * as exec from '@actions/exec';
 import * as fs from 'fs';
 
-const EMULATOR_BOOT_TIMEOUT_SECONDS = 600;
-
 /**
  * Creates and launches a new AVD instance with the specified configurations.
  */
@@ -18,6 +16,7 @@ export async function launchEmulator(
   diskSize: string,
   avdName: string,
   forceAvdCreation: boolean,
+  emulatorBootTimeout: number,
   emulatorOptions: string,
   disableAnimations: boolean,
   disableSpellChecker: boolean,
@@ -77,7 +76,7 @@ export async function launchEmulator(
     });
 
     // wait for emulator to complete booting
-    await waitForDevice();
+    await waitForDevice(emulatorBootTimeout);
     await exec.exec(`adb shell input keyevent 82`);
 
     if (disableAnimations) {
@@ -114,11 +113,11 @@ export async function killEmulator(): Promise<void> {
 /**
  * Wait for emulator to boot.
  */
-async function waitForDevice(): Promise<void> {
+async function waitForDevice(emulatorBootTimeout: number): Promise<void> {
   let booted = false;
   let attempts = 0;
   const retryInterval = 2; // retry every 2 seconds
-  const maxAttempts = EMULATOR_BOOT_TIMEOUT_SECONDS / 2;
+  const maxAttempts = emulatorBootTimeout / 2;
   while (!booted) {
     try {
       let result = '';

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,6 +89,10 @@ async function run() {
     const forceAvdCreation = forceAvdCreationInput === 'true';
     console.log(`force avd creation: ${forceAvdCreation}`);
 
+    // Emulator boot timeout seconds
+    const emulatorBootTimeout = parseInt(core.getInput('emulator-boot-timeout'), 10);
+    console.log(`Emulator boot timeout: ${emulatorBootTimeout}`);
+
     // emulator options
     const emulatorOptions = core.getInput('emulator-options').trim();
     console.log(`emulator options: ${emulatorOptions}`);
@@ -205,6 +209,7 @@ async function run() {
       diskSize,
       avdName,
       forceAvdCreation,
+      emulatorBootTimeout,
       emulatorOptions,
       disableAnimations,
       disableSpellchecker,


### PR DESCRIPTION
### The problem
Often, 10 minutes would not be enough for the emulator to boot on the machines I'm using
![Screenshot from 2023-03-02 01-18-05](https://user-images.githubusercontent.com/2735681/222305922-7b2b1e53-b306-43ea-a96e-8db29d372498.png)

### The fix
Add a new github action parameter so that the timeout is customisable
