### PR TITLE
Bug fix in example code at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+        
+      - name: set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+        
 
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION
Updated Main Usage Example with 

1. chmod  Reason : I got an error of "no permission"

2. JDK 11 Reason : This is needed for supporting Gradle plugin 7.4.1 and above