### PR TITLE
fix: emulator-manager.ts

### DIFF
--- a/src/emulator-manager.ts
+++ b/src/emulator-manager.ts
@@ -32,7 +32,7 @@ export async function launchEmulator(
       const sdcardPathOrSizeOption = sdcardPathOrSize.trim() !== '' ? `--sdcard '${sdcardPathOrSize}'` : '';
       console.log(`Creating AVD.`);
       await exec.exec(
-        `sh -c \\"echo no | avdmanager create avd --force -n "${avdName}" --abi '${target}/${arch}' --package 'system-images;android-${apiLevel};${target};${arch}' ${profileOption} ${sdcardPathOrSizeOption}"`
+        `sh -c \\"echo no | avdmanager create avd --force -n '${avdName}' --abi '${target}/${arch}' --package 'system-images;android-${apiLevel};${target};${arch}' ${profileOption} ${sdcardPathOrSizeOption}"`
       );
     }
 


### PR DESCRIPTION
```
/bin/sh -c \echo no | avdmanager create avd --force -n Pixel 2 --abi 'google_apis_playstore/x86' --package 'system-images;android-30;google_apis_playstore;x86' --device 'pixel_2'
```
with `avd-name : 'Pixel 2'` - fails because of that space

https://github.com/ShootingKing-AM/PhoneVR/actions/runs/4845910864/jobs/8635116789#step:11:69