### PR TITLE
Add arm64-v8a targets to the CI tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         os: [macos-latest, ubuntu-latest]
         api-level: [16, 23, 29]
         target: [default, google_apis]
-        arch: [x86]
+        arch: [x86, arm64-v8a]
         exclude:
           - os: ubuntu-latest
             api-level: 23


### PR DESCRIPTION
I've been having some issues on my project with getting arm64-v8a targets to come up, and noticed that they weren't being tested here. So I'm adding them as test targets to see if they work here.