### PR TITLE
Fixed emulator download URL

### DIFF
--- a/src/sdk-installer.ts
+++ b/src/sdk-installer.ts
@@ -17,6 +17,7 @@ export async function installAndroidSdk(apiLevel: string, target: string, arch: 
   try {
     console.log(`::group::Install Android SDK`);
     const isOnMac = process.platform === 'darwin';
+    const isArm = process.arch === 'arm64';
 
     if (!isOnMac) {
       await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME} -R`);
@@ -50,7 +51,19 @@ export async function installAndroidSdk(apiLevel: string, target: string, arch: 
     if (emulatorBuild) {
       console.log(`Installing emulator build ${emulatorBuild}.`);
       // TODO find out the correct download URLs for all build ids
-      const downloadUrlSuffix = Number(emulatorBuild.charAt(0)) > 6 ? `_x64-${emulatorBuild}` : `-${emulatorBuild}`;
+      var downloadUrlSuffix: string;
+      const majorBuildVersion = Number(emulatorBuild);
+      if (majorBuildVersion >= 8000000) {
+        if (isArm) {
+          downloadUrlSuffix = `_aarch64-${emulatorBuild}`;
+        } else {
+          downloadUrlSuffix = `_x64-${emulatorBuild}`;
+        }
+      } else if (majorBuildVersion >= 7000000) {
+        downloadUrlSuffix = `_x64-${emulatorBuild}`;
+      } else {
+        downloadUrlSuffix = `-${emulatorBuild}`;
+      }
       await exec.exec(`curl -fo emulator.zip https://dl.google.com/android/repository/emulator-${isOnMac ? 'darwin' : 'linux'}${downloadUrlSuffix}.zip`);
       await exec.exec(`unzip -o -q emulator.zip -d ${process.env.ANDROID_HOME}`);
       await io.rmRF('emulator.zip');


### PR DESCRIPTION
Previous code worked in a wrong way. 
1. Getting the first char of a build number is mistake because now numbers start with 1, but whole number higher than the number which starts from 7.
2. URL was incorrect for arm mac machines. It needed to add `aarch64` suffix