### PR TITLE
Migrate to Node 20 on CI via GitHub Actions major upgrades

### DIFF
--- a/.github/workflows/action-types.yml
+++ b/.github/workflows/action-types.yml
@@ -9,5 +9,5 @@ jobs:
   validate-typings:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: krzema12/github-actions-typing@v0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: validate gradle wrapper
       uses: gradle/wrapper-validation-action@v1
@@ -61,12 +61,12 @@ jobs:
         npm run lint
         npm test
 
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: 21
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       id: avd-cache
       with:
         path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,11 +75,11 @@ jobs:
           ~/.android/debug.keystore
         key: avd-${{ matrix.api-level }}-${{ matrix.os }}-${{ matrix.target }}
 
+    - uses: gradle/actions/setup-gradle@v3
+
     - name: assemble tests
-      uses: gradle/gradle-build-action@v2
-      with:
-        build-root-directory: test-fixture
-        arguments: assembleAndroidTest
+      working-directory: test-fixture
+      run: ./gradlew assembleAndroidTest
 
     - name: enable KVM for linux runners
       if: runner.os == 'Linux'

--- a/.github/workflows/manually.yml
+++ b/.github/workflows/manually.yml
@@ -39,7 +39,7 @@ jobs:
     
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: validate gradle wrapper
       uses: gradle/wrapper-validation-action@v1
@@ -51,7 +51,7 @@ jobs:
         npm run lint
         npm test
 
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: 21

--- a/.github/workflows/manually.yml
+++ b/.github/workflows/manually.yml
@@ -56,7 +56,7 @@ jobs:
         distribution: 'zulu'
         java-version: 21
 
-    - uses: gradle/gradle-build-action@v2
+    - uses: gradle/actions/setup-gradle@v3
       with:
         gradle-home-cache-cleanup: true
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Enable KVM
         run: |
@@ -76,7 +76,7 @@ jobs:
         target: [default, google_apis]
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Enable KVM
         run: |
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Enable KVM
         run: |
@@ -122,7 +122,7 @@ jobs:
 We can significantly reduce emulator startup time by setting up AVD snapshot caching:
 
 1. add a `gradle/gradle-build-action@v2` step for caching Gradle, more details see [#229](https://github.com/ReactiveCircus/android-emulator-runner/issues/229)
-2. add an `actions/cache@v3` step for caching the `avd`
+2. add an `actions/cache@v4` step for caching the `avd`
 3. add a `reactivecircus/android-emulator-runner@v2` step to generate a clean snapshot - specify `emulator-options` without `no-snapshot`
 4. add another `reactivecircus/android-emulator-runner@v2` step to run your tests using existing AVD / snapshot - specify `emulator-options` with `no-snapshot-save`
 
@@ -135,7 +135,7 @@ jobs:
         api-level: [21, 23, 29]
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Enable KVM
         run: |
@@ -147,7 +147,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         
       - name: AVD cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: avd-cache
         with:
           path: |

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ jobs:
 
 We can significantly reduce emulator startup time by setting up AVD snapshot caching:
 
-1. add a `gradle/gradle-build-action@v2` step for caching Gradle, more details see [#229](https://github.com/ReactiveCircus/android-emulator-runner/issues/229)
+1. add a `gradle/actions/setup-gradle@v3` step for caching Gradle, more details see [#229](https://github.com/ReactiveCircus/android-emulator-runner/issues/229)
 2. add an `actions/cache@v4` step for caching the `avd`
 3. add a `reactivecircus/android-emulator-runner@v2` step to generate a clean snapshot - specify `emulator-options` without `no-snapshot`
 4. add another `reactivecircus/android-emulator-runner@v2` step to run your tests using existing AVD / snapshot - specify `emulator-options` with `no-snapshot-save`
@@ -144,7 +144,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         
       - name: AVD cache
         uses: actions/cache@v4


### PR DESCRIPTION
Reduce warnings:

![image](https://github.com/ReactiveCircus/android-emulator-runner/assets/2906988/114062fb-03c3-473a-bfbe-59cbd6581412)

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, gradle/wrapper-validation-action@v1, actions/setup-java@v3, actions/cache@v3, gradle/gradle-build-action@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

wrapper-validation doesn't have a version yet: https://github.com/gradle/wrapper-validation-action/issues/160 (it's quite possible it'll end up as `gradle/actions/wrapper-validation@v2` in a few weeks)

Note: most actions treat Node 20 as major bumps because self-hosted runners break down from automatic minor bumps via `@vX`, if there's no Node 20 installed on them.