### PR TITLE
Bump Gradle wrapper validation from v1 to v2 to use Node 20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: validate gradle wrapper
-      uses: gradle/wrapper-validation-action@v1
+      uses: gradle/wrapper-validation-action@v2
 
     - name: build, test and lint
       run: |

--- a/.github/workflows/manually.yml
+++ b/.github/workflows/manually.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: validate gradle wrapper
-      uses: gradle/wrapper-validation-action@v1
+      uses: gradle/wrapper-validation-action@v2
 
     - name: build, test and lint
       run: |


### PR DESCRIPTION
 * Follow-up on https://github.com/ReactiveCircus/android-emulator-runner/pull/372
 * v2 points to https://github.com/gradle/wrapper-validation-action/releases/tag/v2.0.0-rc.1


Fixes warnings on https://github.com/ReactiveCircus/android-emulator-runner/actions/runs/7678503170
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: gradle/wrapper-validation-action@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.