### PR TITLE
Use m1 macos runner.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
             api-level: 30
             target: aosp_atd
             arch: x86
-          - os: macos-latest
+          - os: macos-14
             api-level: 31
             target: google_apis
             arch: x86_64


### PR DESCRIPTION
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/