### PR TITLE
Use `xvfb-run` to run emulator on Linux

### DIFF
--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -70,9 +70,13 @@ function launchEmulator(apiLevel, target, arch, profile, cores, ramSize, heapSiz
                 console.log('Disabling Linux hardware acceleration.');
                 emulatorOptions += ' -accel off';
             }
+            let emulatorCommandPrefix;
+            if (process.platform === 'linux') {
+                emulatorCommandPrefix = 'xvfb-run';
+            }
             // start emulator
             console.log('Starting emulator.');
-            yield exec.exec(`sh -c \\"${process.env.ANDROID_HOME}/emulator/emulator -avd "${avdName}" ${emulatorOptions} &"`, [], {
+            yield exec.exec(`sh -c \\"${emulatorCommandPrefix} ${process.env.ANDROID_HOME}/emulator/emulator -avd "${avdName}" ${emulatorOptions} &"`, [], {
                 listeners: {
                     stderr: (data) => {
                         if (data.toString().includes('invalid command-line parameter')) {

--- a/lib/sdk-installer.js
+++ b/lib/sdk-installer.js
@@ -52,6 +52,7 @@ function installAndroidSdk(apiLevel, target, arch, channelId, emulatorBuild, ndk
             console.log(`::group::Install Android SDK`);
             const isOnMac = process.platform === 'darwin';
             const isArm = process.arch === 'arm64';
+            const isLinux = process.platform === 'linux';
             if (!isOnMac) {
                 yield exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME} -R`);
             }
@@ -105,6 +106,10 @@ function installAndroidSdk(apiLevel, target, arch, channelId, emulatorBuild, ndk
             if (cmakeVersion) {
                 console.log(`Installing CMake ${cmakeVersion}.`);
                 yield exec.exec(`sh -c \\"sdkmanager --install 'cmake;${cmakeVersion}' --channel=${channelId} > /dev/null"`);
+            }
+            if (isLinux) {
+                console.log('Installing emulator dependencies.');
+                yield exec.exec(`sh -c \\"sudo apt install libpulse0 xvfb"`);
             }
         }
         finally {

--- a/src/emulator-manager.ts
+++ b/src/emulator-manager.ts
@@ -62,10 +62,16 @@ export async function launchEmulator(
       emulatorOptions += ' -accel off';
     }
 
+    let emulatorCommandPrefix;
+
+    if (process.platform === 'linux') {
+      emulatorCommandPrefix = 'xvfb-run'
+    }
+
     // start emulator
     console.log('Starting emulator.');
 
-    await exec.exec(`sh -c \\"${process.env.ANDROID_HOME}/emulator/emulator -avd "${avdName}" ${emulatorOptions} &"`, [], {
+    await exec.exec(`sh -c \\"${emulatorCommandPrefix} ${process.env.ANDROID_HOME}/emulator/emulator -avd "${avdName}" ${emulatorOptions} &"`, [], {
       listeners: {
         stderr: (data: Buffer) => {
           if (data.toString().includes('invalid command-line parameter')) {

--- a/src/sdk-installer.ts
+++ b/src/sdk-installer.ts
@@ -18,6 +18,7 @@ export async function installAndroidSdk(apiLevel: string, target: string, arch: 
     console.log(`::group::Install Android SDK`);
     const isOnMac = process.platform === 'darwin';
     const isArm = process.arch === 'arm64';
+    const isLinux = process.platform === 'linux';
 
     if (!isOnMac) {
       await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME} -R`);
@@ -78,6 +79,10 @@ export async function installAndroidSdk(apiLevel: string, target: string, arch: 
     if (cmakeVersion) {
       console.log(`Installing CMake ${cmakeVersion}.`);
       await exec.exec(`sh -c \\"sdkmanager --install 'cmake;${cmakeVersion}' --channel=${channelId} > /dev/null"`);
+    }
+    if (isLinux) {
+      console.log('Installing emulator dependencies.');
+      await exec.exec(`sh -c \\"sudo apt install libpulse0 xvfb"`)
     }
   } finally {
     console.log(`::endgroup::`);


### PR DESCRIPTION
Latest emulator versions (34?) bundled with Qt library which only have XCB backend. So we need to run X11 to start emulator correctly.