### PR TITLE
Install platforms for the specified api level

### DIFF
--- a/lib/sdk-installer.js
+++ b/lib/sdk-installer.js
@@ -70,7 +70,7 @@ function installAndroidSdk(apiLevel, target, arch, channelId, emulatorBuild, ndk
             // accept all Android SDK licenses
             yield exec.exec(`sh -c \\"yes | sdkmanager --licenses > /dev/null"`);
             console.log('Installing latest build tools, platform tools, and platform.');
-            yield exec.exec(`sh -c \\"sdkmanager --install 'build-tools;${BUILD_TOOLS_VERSION}' platform-tools > /dev/null"`);
+            yield exec.exec(`sh -c \\"sdkmanager --install 'build-tools;${BUILD_TOOLS_VERSION}' platform-tools 'platforms:android-${apiLevel}'> /dev/null"`);
             console.log('Installing latest emulator.');
             yield exec.exec(`sh -c \\"sdkmanager --install emulator --channel=${channelId} > /dev/null"`);
             if (emulatorBuild) {

--- a/lib/sdk-installer.js
+++ b/lib/sdk-installer.js
@@ -70,7 +70,7 @@ function installAndroidSdk(apiLevel, target, arch, channelId, emulatorBuild, ndk
             // accept all Android SDK licenses
             yield exec.exec(`sh -c \\"yes | sdkmanager --licenses > /dev/null"`);
             console.log('Installing latest build tools, platform tools, and platform.');
-            yield exec.exec(`sh -c \\"sdkmanager --install 'build-tools;${BUILD_TOOLS_VERSION}' platform-tools 'platforms:android-${apiLevel}'> /dev/null"`);
+            yield exec.exec(`sh -c \\"sdkmanager --install 'build-tools;${BUILD_TOOLS_VERSION}' platform-tools 'platforms;android-${apiLevel}'> /dev/null"`);
             console.log('Installing latest emulator.');
             yield exec.exec(`sh -c \\"sdkmanager --install emulator --channel=${channelId} > /dev/null"`);
             if (emulatorBuild) {

--- a/src/sdk-installer.ts
+++ b/src/sdk-installer.ts
@@ -43,7 +43,7 @@ export async function installAndroidSdk(apiLevel: string, target: string, arch: 
 
     console.log('Installing latest build tools, platform tools, and platform.');
 
-    await exec.exec(`sh -c \\"sdkmanager --install 'build-tools;${BUILD_TOOLS_VERSION}' platform-tools 'platforms:android-${apiLevel}'> /dev/null"`);
+    await exec.exec(`sh -c \\"sdkmanager --install 'build-tools;${BUILD_TOOLS_VERSION}' platform-tools 'platforms;android-${apiLevel}'> /dev/null"`);
 
     console.log('Installing latest emulator.');
     await exec.exec(`sh -c \\"sdkmanager --install emulator --channel=${channelId} > /dev/null"`);

--- a/src/sdk-installer.ts
+++ b/src/sdk-installer.ts
@@ -43,7 +43,7 @@ export async function installAndroidSdk(apiLevel: string, target: string, arch: 
 
     console.log('Installing latest build tools, platform tools, and platform.');
 
-    await exec.exec(`sh -c \\"sdkmanager --install 'build-tools;${BUILD_TOOLS_VERSION}' platform-tools > /dev/null"`);
+    await exec.exec(`sh -c \\"sdkmanager --install 'build-tools;${BUILD_TOOLS_VERSION}' platform-tools 'platforms:android-${apiLevel}'> /dev/null"`);
 
     console.log('Installing latest emulator.');
     await exec.exec(`sh -c \\"sdkmanager --install emulator --channel=${channelId} > /dev/null"`);


### PR DESCRIPTION
When using this action in multiple projects that both build and test Android apps on shared self-hosted runners. We are having emulator launch issues because the platform is missing in the Android SDK.

When only building, we use the [setup-android ](https://github.com/android-actions/setup-android)action to install the Android SDK. If another test build hits the same self-hosted runner with a cached Android SDK directory, the platforms directory does not get installed by this GH action.

```bash
WARNING | platforms subdirectory is missing under /Users/ec2-user/.android/sdk, please install it
  WARNING | invalid sdk root /Users/ec2-user/.android/sdk
  PANIC: Broken AVD system path. Check your ANDROID_SDK_ROOT value [/Users/ec2-user/.android/sdk]!
  INFO    | Android emulator version 32.1.15.0 (build_id 10696886) (CL:N/A)
  INFO    | checking ANDROID_HOME for valid sdk root.
  INFO    | checking ANDROID_SDK_ROOT for valid sdk root.
  emulator: WARN: Cannot find valid sdk root from environment variable ANDROID_HOME nor ANDROID_SDK_ROOT,Try to infer from emulator's path
  INFO    | guessed sdk root is /Users/ec2-user/.android/sdk
  emulator: WARN: Cannot find valid sdk root path.
```

It seems like other people are also running into the same issue, ie -> https://github.com/ReactiveCircus/android-emulator-runner/issues/375