### PR TITLE
Only overwrite ANDROID_AVD_HOME if not set

### DIFF
--- a/src/sdk-installer.ts
+++ b/src/sdk-installer.ts
@@ -35,8 +35,10 @@ export async function installAndroidSdk(apiLevel: string, target: string, arch: 
     // add paths for commandline-tools and platform-tools
     core.addPath(`${cmdlineToolsPath}/latest:${cmdlineToolsPath}/latest/bin:${process.env.ANDROID_HOME}/platform-tools`);
 
-    // set standard AVD path
-    core.exportVariable('ANDROID_AVD_HOME', `${process.env.HOME}/.android/avd`);
+    // set standard AVD path if not set
+    if (!process.env.ANDROID_AVD_HOME) {
+      core.exportVariable('ANDROID_AVD_HOME', `${process.env.HOME}/.android/avd`);
+    }
 
     // accept all Android SDK licenses
     await exec.exec(`sh -c \\"yes | sdkmanager --licenses > /dev/null"`);


### PR DESCRIPTION
The path might point to a different path than what android-emulator-runner expects, like when XDG_CONFIG_HOME is set.