### PR TITLE
Avoid changing the owner of unnecessary files

### DIFF
--- a/lib/sdk-installer.js
+++ b/lib/sdk-installer.js
@@ -53,7 +53,9 @@ function installAndroidSdk(apiLevel, target, arch, channelId, emulatorBuild, ndk
             const isOnMac = process.platform === 'darwin';
             const isArm = process.arch === 'arm64';
             if (!isOnMac) {
-                yield exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME} -R`);
+                yield exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/platform-tools -R`);
+                yield exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/cmdline-tools/latest -R`);
+                yield exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/build-tools/${BUILD_TOOLS_VERSION} -R`);
             }
             const cmdlineToolsPath = `${process.env.ANDROID_HOME}/cmdline-tools`;
             if (!fs.existsSync(cmdlineToolsPath)) {

--- a/src/sdk-installer.ts
+++ b/src/sdk-installer.ts
@@ -20,7 +20,10 @@ export async function installAndroidSdk(apiLevel: string, target: string, arch: 
     const isArm = process.arch === 'arm64';
 
     if (!isOnMac) {
-      await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME} -R`);
+      await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/platform-tools -R`);
+      await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/tools -R`);
+      await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/build-tools/${BUILD_TOOLS_VERSION} -R`);
+      await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/emulator -R`);
     }
 
     const cmdlineToolsPath = `${process.env.ANDROID_HOME}/cmdline-tools`;

--- a/src/sdk-installer.ts
+++ b/src/sdk-installer.ts
@@ -21,7 +21,7 @@ export async function installAndroidSdk(apiLevel: string, target: string, arch: 
 
     if (!isOnMac) {
       await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/platform-tools -R`);
-      await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/tools -R`);
+      await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/cmdline-tools/latest -R`);
       await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/build-tools/${BUILD_TOOLS_VERSION} -R`);
       await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/emulator -R`);
     }

--- a/src/sdk-installer.ts
+++ b/src/sdk-installer.ts
@@ -23,7 +23,6 @@ export async function installAndroidSdk(apiLevel: string, target: string, arch: 
       await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/platform-tools -R`);
       await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/cmdline-tools/latest -R`);
       await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/build-tools/${BUILD_TOOLS_VERSION} -R`);
-      await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/emulator -R`);
     }
 
     const cmdlineToolsPath = `${process.env.ANDROID_HOME}/cmdline-tools`;


### PR DESCRIPTION
There's probably even more precision to be had, but this seems like a good step forward. This is a different approach to the same problem as #344. I'd be happy to close this in favor of that one!

Source files shouldn't matter for the purposes of this tool. There are a number of files.
```
 % ls -R $ANDROID_HOME/sources/android-34 | wc -l       
   17750
```