### PR TITLE
SDK build tools 35.0.0, command-line tools 16.0.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,8 +36,8 @@ jobs:
             target: aosp_atd
             arch: x86_64
           - os: macos-latest
-            api-level: 35
-            target: google_apis
+            api-level: 29
+            target: default
             arch: arm64-v8a
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,15 +27,15 @@ jobs:
             api-level: 24
             target: playstore
             arch: x86
-          - os: ubuntu-latest
+          - os: macos-13
             api-level: 31
-            target: aosp_atd
+            target: default
             arch: x86_64
           - os: ubuntu-latest
             api-level: 34
             target: aosp_atd
             arch: x86_64
-          - os: macos-13
+          - os: ubuntu-latest
             api-level: 35
             target: google_apis
             arch: x86_64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,14 +31,18 @@ jobs:
             api-level: 31
             target: aosp_atd
             arch: x86_64
+          - os: macos-latest
+            api-level: 33
+            target: aosp_atd
+            arch: arm64-v8a
           - os: ubuntu-latest
             api-level: 34
             target: aosp_atd
             arch: x86_64
-          - os: macos-latest
-            api-level: 34
-            target: aosp_atd
-            arch: arm64-v8a
+          - os: ubuntu-latest
+            api-level: 35
+            target: google_apis
+            arch: x86_64
 
     steps:
     - name: checkout
@@ -93,7 +97,7 @@ jobs:
         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: false
         working-directory: ./test-fixture/
-        channel: canary
+        channel: stable
         script: echo "Generated AVD snapshot for caching."
 
     - name: run action

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
           - os: macos-latest
             api-level: 33
             target: aosp_atd
-            arch: arm64-v8a
+            arch: x86_64
           - os: ubuntu-latest
             api-level: 34
             target: aosp_atd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,15 +20,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         api-level: [23, 29]
-        target: [default, google_apis]
+        target: [default]
         arch: [x86]
-        exclude:
-          - target: google_apis
-            api-level: 16
-          - target: google_apis
-            api-level: 23
-          - target: google_apis
-            api-level: 29
         include:
           - os: ubuntu-latest
             api-level: 24

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,15 +31,11 @@ jobs:
             api-level: 31
             target: aosp_atd
             arch: x86_64
-          - os: macos-latest
-            api-level: 33
-            target: aosp_atd
-            arch: x86_64
           - os: ubuntu-latest
             api-level: 34
             target: aosp_atd
             arch: x86_64
-          - os: ubuntu-latest
+          - os: macos-13
             api-level: 35
             target: google_apis
             arch: x86_64
@@ -97,7 +93,7 @@ jobs:
         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: false
         working-directory: ./test-fixture/
-        channel: stable
+        channel: canary
         script: echo "Generated AVD snapshot for caching."
 
     - name: run action

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
             target: playstore
             arch: x86
           - os: ubuntu-latest
-            api-level: 30
+            api-level: 31
             target: aosp_atd
             arch: x86_64
           - os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,25 +19,22 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        api-level: [23]
-        target: [default]
-        arch: [x86]
         include:
-          - os: ubuntu-latest
-            api-level: 24
+          - api-level: 23
+            target: default
+            arch: x86
+          - api-level: 24
             target: playstore
             arch: x86
-          - os: ubuntu-latest
-            api-level: 31
+          - api-level: 31
             target: aosp_atd
             arch: x86_64
-          - os: ubuntu-latest
-            api-level: 34
+          - api-level: 34
             target: aosp_atd
             arch: x86_64
           - os: macos-latest
-            api-level: 29
-            target: default
+            api-level: 26
+            target: google_apis
             arch: arm64-v8a
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,18 +18,21 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ubuntu-latest]
         include:
-          - api-level: 23
+          - os: ubuntu-latest
+            api-level: 23
             target: default
             arch: x86
-          - api-level: 24
+          - os: ubuntu-latest
+            api-level: 24
             target: playstore
             arch: x86
-          - api-level: 31
+          - os: ubuntu-latest
+            api-level: 31
             target: aosp_atd
             arch: x86_64
-          - api-level: 34
+          - os: ubuntu-latest
+            api-level: 34
             target: aosp_atd
             arch: x86_64
           - os: macos-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           - os: macos-latest
             api-level: 35
             target: google_apis
-            arch: x86_64
+            arch: arm64-v8a
 
     steps:
     - name: checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        api-level: [23, 29]
+        api-level: [23]
         target: [default]
         arch: [x86]
         include:
@@ -30,7 +30,7 @@ jobs:
           - os: ubuntu-latest
             api-level: 30
             target: aosp_atd
-            arch: x86
+            arch: x86_64
           - os: ubuntu-latest
             api-level: 34
             target: aosp_atd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,13 +38,13 @@ jobs:
             api-level: 30
             target: aosp_atd
             arch: x86
-          - os: macos-latest
-            api-level: 31
-            target: google_apis
-            arch: x86_64
           - os: ubuntu-latest
             api-level: 34
             target: aosp_atd
+            arch: x86_64
+          - os: macos-latest
+            api-level: 35
+            target: google_apis
             arch: x86_64
 
     steps:
@@ -64,7 +64,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
-        java-version: 21
+        java-version: 23
 
     - uses: actions/cache@v4
       id: avd-cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,9 +44,6 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
 
-    - name: validate gradle wrapper
-      uses: gradle/wrapper-validation-action@v2
-
     - name: build, test and lint
       run: |
         npm install
@@ -68,7 +65,7 @@ jobs:
           ~/.android/debug.keystore
         key: avd-${{ matrix.api-level }}-${{ matrix.os }}-${{ matrix.target }}
 
-    - uses: gradle/actions/setup-gradle@v3
+    - uses: gradle/actions/setup-gradle@v4
 
     - name: assemble tests
       working-directory: test-fixture

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,8 +36,8 @@ jobs:
             target: aosp_atd
             arch: x86_64
           - os: macos-latest
-            api-level: 26
-            target: google_apis
+            api-level: 34
+            target: aosp_atd
             arch: arm64-v8a
 
     steps:

--- a/.github/workflows/manually.yml
+++ b/.github/workflows/manually.yml
@@ -41,9 +41,6 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
 
-    - name: validate gradle wrapper
-      uses: gradle/wrapper-validation-action@v2
-
     - name: build, test and lint
       run: |
         npm install
@@ -56,9 +53,7 @@ jobs:
         distribution: 'zulu'
         java-version: 23
 
-    - uses: gradle/actions/setup-gradle@v3
-      with:
-        gradle-home-cache-cleanup: true
+    - uses: gradle/actions/setup-gradle@v4
 
     - name: enable KVM for linux runners
       if: runner.os == 'Linux'

--- a/.github/workflows/manually.yml
+++ b/.github/workflows/manually.yml
@@ -9,14 +9,14 @@ on:
       api-level:
         description: 'API level of the platform and system image'
         required: true
-        default: '30'
+        default: '34'
       target:
         description: 'target of the system image - default, google_apis, google_apis_playstore, aosp_atd, google_atd, android-wear, android-wear-cn, android-tv or google-tv'
         required: true
         default: 'default'
       arch:
         description: 'CPU architecture of the system image - x86, x86_64 or arm64-v8a'
-        default: 'x86'
+        default: 'x86_64'
       emulator-options:
         description: 'command-line options used when launching the emulator'
         default: '-no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim'
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
-        java-version: 21
+        java-version: 23
 
     - uses: gradle/actions/setup-gradle@v3
       with:

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ jobs:
 
 We can significantly reduce emulator startup time by setting up AVD snapshot caching:
 
-1. add a `gradle/actions/setup-gradle@v3` step for caching Gradle, more details see [#229](https://github.com/ReactiveCircus/android-emulator-runner/issues/229)
+1. add a `gradle/actions/setup-gradle@v4` step for caching Gradle, more details see [#229](https://github.com/ReactiveCircus/android-emulator-runner/issues/229)
 2. add an `actions/cache@v4` step for caching the `avd`
 3. add a `reactivecircus/android-emulator-runner@v2` step to generate a clean snapshot - specify `emulator-options` without `no-snapshot`
 4. add another `reactivecircus/android-emulator-runner@v2` step to run your tests using existing AVD / snapshot - specify `emulator-options` with `no-snapshot-save`

--- a/lib/sdk-installer.js
+++ b/lib/sdk-installer.js
@@ -38,10 +38,10 @@ const exec = __importStar(require("@actions/exec"));
 const io = __importStar(require("@actions/io"));
 const tc = __importStar(require("@actions/tool-cache"));
 const fs = __importStar(require("fs"));
-const BUILD_TOOLS_VERSION = '34.0.0';
-// SDK command-line tools 11.0
-const CMDLINE_TOOLS_URL_MAC = 'https://dl.google.com/android/repository/commandlinetools-mac-10406996_latest.zip';
-const CMDLINE_TOOLS_URL_LINUX = 'https://dl.google.com/android/repository/commandlinetools-linux-10406996_latest.zip';
+const BUILD_TOOLS_VERSION = '35.0.0';
+// SDK command-line tools 16.0
+const CMDLINE_TOOLS_URL_MAC = 'https://dl.google.com/android/repository/commandlinetools-mac-12266719_latest.zip';
+const CMDLINE_TOOLS_URL_LINUX = 'https://dl.google.com/android/repository/commandlinetools-linux-12266719_latest.zip';
 /**
  * Installs & updates the Android SDK for the macOS platform, including SDK platform for the chosen API level, latest build tools, platform tools, Android Emulator,
  * and the system image for the chosen API level, CPU arch, and target.

--- a/src/sdk-installer.ts
+++ b/src/sdk-installer.ts
@@ -4,10 +4,10 @@ import * as io from '@actions/io';
 import * as tc from '@actions/tool-cache';
 import * as fs from 'fs';
 
-const BUILD_TOOLS_VERSION = '34.0.0';
-// SDK command-line tools 11.0
-const CMDLINE_TOOLS_URL_MAC = 'https://dl.google.com/android/repository/commandlinetools-mac-10406996_latest.zip';
-const CMDLINE_TOOLS_URL_LINUX = 'https://dl.google.com/android/repository/commandlinetools-linux-10406996_latest.zip';
+const BUILD_TOOLS_VERSION = '35.0.0';
+// SDK command-line tools 16.0
+const CMDLINE_TOOLS_URL_MAC = 'https://dl.google.com/android/repository/commandlinetools-mac-12266719_latest.zip';
+const CMDLINE_TOOLS_URL_LINUX = 'https://dl.google.com/android/repository/commandlinetools-linux-12266719_latest.zip';
 
 /**
  * Installs & updates the Android SDK for the macOS platform, including SDK platform for the chosen API level, latest build tools, platform tools, Android Emulator,

--- a/test-fixture/app/build.gradle
+++ b/test-fixture/app/build.gradle
@@ -30,7 +30,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.7.9'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/test-fixture/app/build.gradle
+++ b/test-fixture/app/build.gradle
@@ -4,13 +4,13 @@ apply plugin: 'kotlin-android'
 android {
     namespace = "com.example.testapp"
 
-    compileSdkVersion 34
-    buildToolsVersion "34.0.0"
+    compileSdkVersion 35
+    buildToolsVersion "35.0.0"
 
     defaultConfig {
         applicationId "com.example.testapp"
         minSdkVersion 15
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode 1
         versionName "1.0"
 
@@ -30,8 +30,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    implementation 'androidx.appcompat:appcompat:1.7.9'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/test-fixture/app/build.gradle
+++ b/test-fixture/app/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId "com.example.testapp"
-        minSdkVersion 15
+        minSdkVersion 21
         targetSdkVersion 35
         versionCode 1
         versionName "1.0"

--- a/test-fixture/build.gradle
+++ b/test-fixture/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.21"
+        classpath 'com.android.tools.build:gradle:8.7.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.20"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/test-fixture/gradle/wrapper/gradle-wrapper.properties
+++ b/test-fixture/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Also fixed test workflow - changed `macos-latest` to `macos-13` as running on M1 mac isn't supported.