### PR TITLE
fix(ubuntu): specify all avd-related environment variables

### DIFF
--- a/lib/sdk-installer.js
+++ b/lib/sdk-installer.js
@@ -62,9 +62,25 @@ function installAndroidSdk(apiLevel, target, arch, channelId, emulatorBuild, ndk
             }
             // add paths for commandline-tools and platform-tools
             core.addPath(`${cmdlineToolsPath}/latest:${cmdlineToolsPath}/latest/bin:${process.env.ANDROID_HOME}/platform-tools`);
-            // set standard AVD path
-            yield io.mkdirP(`${process.env.HOME}/.android/avd`);
-            core.exportVariable('ANDROID_AVD_HOME', `${process.env.HOME}/.android/avd`);
+            // There are several environment variables that determine where AVD config and disk images go:
+            // https://developer.android.com/tools/variables#envar
+            // Users may set these for various reasons (self-hosted runners with specific disk space situations)
+            // so only set them if they are not already set.
+            // "user preferences directory for tools that are part of the Android SDK. Defaults to $HOME/.android/."
+            if (!process.env.ANDROID_USER_HOME) {
+                core.exportVariable('ANDROID_USER_HOME', `${process.env.HOME}/.android`);
+            }
+            yield io.mkdirP(`${process.env.ANDROID_USER_HOME}`);
+            // "user-specific emulator configuration directory. Defaults to $ANDROID_USER_HOME"
+            if (!process.env.ANDROID_EMULATOR_HOME) {
+                core.exportVariable('ANDROID_EMULATOR_HOME', process.env.ANDROID_USER_HOME);
+            }
+            yield io.mkdirP(`${process.env.ANDROID_EMULATOR_HOME}`);
+            // "all AVD-specific files, which mostly consist of very large disk images. Default is $ANDROID_EMULATOR_HOME/avd/"
+            if (!process.env.ANDROID_AVD_HOME) {
+                core.exportVariable('ANDROID_AVD_HOME', `${process.env.ANDROID_EMULATOR_HOME}/avd`);
+            }
+            yield io.mkdirP(`${process.env.ANDROID_AVD_HOME}`);
             // accept all Android SDK licenses
             yield exec.exec(`sh -c \\"yes | sdkmanager --licenses > /dev/null"`);
             console.log('Installing latest build tools, platform tools, and platform.');


### PR DESCRIPTION

This action does simply define all of the standard env vars per the android documentation https://developer.android.com/tools/variables#envar

Additionally, it forcibly overwrites those variables though there may be valid reasons that they exist already:

1- for self-hosted runners people may define the variables so the large AVD files are in a non-standard location
2- for ubuntu-24 with XDG_CONFIG_HOME set (vs ubuntu-22) one of the variables was already set, but to an unexpected location. You can either clobber it and install (which works) or you can take it and use it (which was also a valid workaround)

This PR attempts to respect the variables *if* they exist, but make sure they are all set + directories are created either way

Osoletes #405