### PR TITLE
fix(ubuntu): chown more safely

### DIFF
--- a/lib/sdk-installer.js
+++ b/lib/sdk-installer.js
@@ -53,9 +53,10 @@ function installAndroidSdk(apiLevel, target, arch, channelId, emulatorBuild, ndk
             const isOnMac = process.platform === 'darwin';
             const isArm = process.arch === 'arm64';
             if (!isOnMac) {
-                yield exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/platform-tools -R`);
-                yield exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/cmdline-tools/latest -R`);
-                yield exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/build-tools/${BUILD_TOOLS_VERSION} -R`);
+                yield exec.exec(`sh -c "sudo chown $USER:$USER ${process.env.ANDROID_HOME}"`);
+                yield exec.exec(`sh -c "sudo chown -R $USER:$USER ${process.env.ANDROID_HOME}/platform-tools || true"`);
+                yield exec.exec(`sh -c "sudo chown -R $USER:$USER ${process.env.ANDROID_HOME}/cmdline-tools/latest || true"`);
+                yield exec.exec(`sh -c "sudo chown -R $USER:$USER ${process.env.ANDROID_HOME}/build-tools/${BUILD_TOOLS_VERSION} || true"`);
             }
             const cmdlineToolsPath = `${process.env.ANDROID_HOME}/cmdline-tools`;
             if (!fs.existsSync(cmdlineToolsPath)) {

--- a/src/sdk-installer.ts
+++ b/src/sdk-installer.ts
@@ -20,9 +20,10 @@ export async function installAndroidSdk(apiLevel: string, target: string, arch: 
     const isArm = process.arch === 'arm64';
 
     if (!isOnMac) {
-      await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/platform-tools -R`);
-      await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/cmdline-tools/latest -R`);
-      await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/build-tools/${BUILD_TOOLS_VERSION} -R`);
+      await exec.exec(`sh -c "sudo chown $USER:$USER ${process.env.ANDROID_HOME}"`);
+      await exec.exec(`sh -c "sudo chown -R $USER:$USER ${process.env.ANDROID_HOME}/platform-tools || true"`);
+      await exec.exec(`sh -c "sudo chown -R $USER:$USER ${process.env.ANDROID_HOME}/cmdline-tools/latest || true"`);
+      await exec.exec(`sh -c "sudo chown -R $USER:$USER ${process.env.ANDROID_HOME}/build-tools/${BUILD_TOOLS_VERSION} || true"`);
     }
 
     const cmdlineToolsPath = `${process.env.ANDROID_HOME}/cmdline-tools`;


### PR DESCRIPTION
- make sure the root of android stuff is chowned for installation of completely new things if needed
- don't fail when recursively chowning specific android things, as they may not exist yet (i.e., platform-tools) when chown is attempted