### PR TITLE
Revert creating avd directory.

### DIFF
--- a/lib/sdk-installer.js
+++ b/lib/sdk-installer.js
@@ -52,11 +52,6 @@ function installAndroidSdk(apiLevel, target, arch, channelId, emulatorBuild, ndk
             console.log(`::group::Install Android SDK`);
             const isOnMac = process.platform === 'darwin';
             const isArm = process.arch === 'arm64';
-            if (!isOnMac) {
-                yield exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/platform-tools -R`);
-                yield exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/cmdline-tools/latest -R`);
-                yield exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/build-tools/${BUILD_TOOLS_VERSION} -R`);
-            }
             const cmdlineToolsPath = `${process.env.ANDROID_HOME}/cmdline-tools`;
             if (!fs.existsSync(cmdlineToolsPath)) {
                 console.log('Installing new cmdline-tools.');

--- a/lib/sdk-installer.js
+++ b/lib/sdk-installer.js
@@ -52,6 +52,11 @@ function installAndroidSdk(apiLevel, target, arch, channelId, emulatorBuild, ndk
             console.log(`::group::Install Android SDK`);
             const isOnMac = process.platform === 'darwin';
             const isArm = process.arch === 'arm64';
+            if (!isOnMac) {
+                yield exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/platform-tools -R`);
+                yield exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/cmdline-tools/latest -R`);
+                yield exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/build-tools/${BUILD_TOOLS_VERSION} -R`);
+            }
             const cmdlineToolsPath = `${process.env.ANDROID_HOME}/cmdline-tools`;
             if (!fs.existsSync(cmdlineToolsPath)) {
                 console.log('Installing new cmdline-tools.');
@@ -63,7 +68,6 @@ function installAndroidSdk(apiLevel, target, arch, channelId, emulatorBuild, ndk
             // add paths for commandline-tools and platform-tools
             core.addPath(`${cmdlineToolsPath}/latest:${cmdlineToolsPath}/latest/bin:${process.env.ANDROID_HOME}/platform-tools`);
             // set standard AVD path
-            yield io.mkdirP(`${process.env.HOME}/.android/avd`);
             core.exportVariable('ANDROID_AVD_HOME', `${process.env.HOME}/.android/avd`);
             // accept all Android SDK licenses
             yield exec.exec(`sh -c \\"yes | sdkmanager --licenses > /dev/null"`);

--- a/src/sdk-installer.ts
+++ b/src/sdk-installer.ts
@@ -19,12 +19,6 @@ export async function installAndroidSdk(apiLevel: string, target: string, arch: 
     const isOnMac = process.platform === 'darwin';
     const isArm = process.arch === 'arm64';
 
-    if (!isOnMac) {
-      await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/platform-tools -R`);
-      await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/cmdline-tools/latest -R`);
-      await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/build-tools/${BUILD_TOOLS_VERSION} -R`);
-    }
-
     const cmdlineToolsPath = `${process.env.ANDROID_HOME}/cmdline-tools`;
     if (!fs.existsSync(cmdlineToolsPath)) {
       console.log('Installing new cmdline-tools.');

--- a/src/sdk-installer.ts
+++ b/src/sdk-installer.ts
@@ -19,6 +19,12 @@ export async function installAndroidSdk(apiLevel: string, target: string, arch: 
     const isOnMac = process.platform === 'darwin';
     const isArm = process.arch === 'arm64';
 
+    if (!isOnMac) {
+      await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/platform-tools -R`);
+      await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/cmdline-tools/latest -R`);
+      await exec.exec(`sh -c \\"sudo chown $USER:$USER ${process.env.ANDROID_HOME}/build-tools/${BUILD_TOOLS_VERSION} -R`);
+    }
+
     const cmdlineToolsPath = `${process.env.ANDROID_HOME}/cmdline-tools`;
     if (!fs.existsSync(cmdlineToolsPath)) {
       console.log('Installing new cmdline-tools.');
@@ -32,7 +38,6 @@ export async function installAndroidSdk(apiLevel: string, target: string, arch: 
     core.addPath(`${cmdlineToolsPath}/latest:${cmdlineToolsPath}/latest/bin:${process.env.ANDROID_HOME}/platform-tools`);
 
     // set standard AVD path
-    await io.mkdirP(`${process.env.HOME}/.android/avd`);
     core.exportVariable('ANDROID_AVD_HOME', `${process.env.HOME}/.android/avd`);
 
     // accept all Android SDK licenses


### PR DESCRIPTION
Seems like the issue with `24.04` has been fixed from upstream so the changes in https://github.com/ReactiveCircus/android-emulator-runner/pull/409 are no longer required.

Changing the owner of the Android SDK path is no longer needed so we're keeping that change.