### PR TITLE
Fix avd path on ubuntu-24.04 - attempt 2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
             api-level: 34
             target: aosp_atd
             arch: x86_64
-          - os: ubuntu-24.04
+          - os: ubuntu-lastest
             api-level: 35
             target: google_apis
             arch: x86_64
@@ -56,14 +56,14 @@ jobs:
         distribution: 'zulu'
         java-version: 23
 
-    - uses: actions/cache@v4
-      id: avd-cache
-      with:
-        path: |
-          ~/.android/avd/*
-          ~/.android/adb*
-          ~/.android/debug.keystore
-        key: avd-${{ matrix.api-level }}-${{ matrix.os }}-${{ matrix.target }}
+    # - uses: actions/cache@v4
+    #   id: avd-cache
+    #   with:
+    #     path: |
+    #       ~/.android/avd/*
+    #       ~/.android/adb*
+    #       ~/.android/debug.keystore
+    #     key: avd-${{ matrix.api-level }}-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.arch }}
 
     - uses: gradle/actions/setup-gradle@v4
 
@@ -78,23 +78,23 @@ jobs:
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
 
-    - name: run emulator to generate snapshot for caching
-      if: steps.avd-cache.outputs.cache-hit != 'true'
-      uses: ./
-      with:
-        api-level: ${{ matrix.api-level }}
-        target: ${{ matrix.target }}
-        arch: ${{ matrix.arch }}
-        profile: Galaxy Nexus
-        cores: 2
-        sdcard-path-or-size: 100M
-        avd-name: test
-        force-avd-creation: false
-        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-        disable-animations: false
-        working-directory: ./test-fixture/
-        channel: canary
-        script: echo "Generated AVD snapshot for caching."
+    # - name: run emulator to generate snapshot for caching
+    #   if: steps.avd-cache.outputs.cache-hit != 'true'
+    #   uses: ./
+    #   with:
+    #     api-level: ${{ matrix.api-level }}
+    #     target: ${{ matrix.target }}
+    #     arch: ${{ matrix.arch }}
+    #     profile: Galaxy Nexus
+    #     cores: 2
+    #     sdcard-path-or-size: 100M
+    #     avd-name: test
+    #     force-avd-creation: false
+    #     emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+    #     disable-animations: false
+    #     working-directory: ./test-fixture/
+    #     channel: canary
+    #     script: echo "Generated AVD snapshot for caching."
 
     - name: run action
       uses: ./

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,14 +56,14 @@ jobs:
         distribution: 'zulu'
         java-version: 23
 
-    # - uses: actions/cache@v4
-    #   id: avd-cache
-    #   with:
-    #     path: |
-    #       ~/.android/avd/*
-    #       ~/.android/adb*
-    #       ~/.android/debug.keystore
-    #     key: avd-${{ matrix.api-level }}-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.arch }}
+    - uses: actions/cache@v4
+      id: avd-cache
+      with:
+        path: |
+          ~/.android/avd/*
+          ~/.android/adb*
+          ~/.android/debug.keystore
+        key: avd-${{ matrix.api-level }}-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.arch }}
 
     - uses: gradle/actions/setup-gradle@v4
 
@@ -78,23 +78,23 @@ jobs:
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
 
-    # - name: run emulator to generate snapshot for caching
-    #   if: steps.avd-cache.outputs.cache-hit != 'true'
-    #   uses: ./
-    #   with:
-    #     api-level: ${{ matrix.api-level }}
-    #     target: ${{ matrix.target }}
-    #     arch: ${{ matrix.arch }}
-    #     profile: Galaxy Nexus
-    #     cores: 2
-    #     sdcard-path-or-size: 100M
-    #     avd-name: test
-    #     force-avd-creation: false
-    #     emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-    #     disable-animations: false
-    #     working-directory: ./test-fixture/
-    #     channel: canary
-    #     script: echo "Generated AVD snapshot for caching."
+    - name: run emulator to generate snapshot for caching
+      if: steps.avd-cache.outputs.cache-hit != 'true'
+      uses: ./
+      with:
+        api-level: ${{ matrix.api-level }}
+        target: ${{ matrix.target }}
+        arch: ${{ matrix.arch }}
+        profile: Galaxy Nexus
+        cores: 2
+        sdcard-path-or-size: 100M
+        avd-name: test
+        force-avd-creation: false
+        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: false
+        working-directory: ./test-fixture/
+        channel: canary
+        script: echo "Generated AVD snapshot for caching."
 
     - name: run action
       uses: ./

--- a/lib/sdk-installer.js
+++ b/lib/sdk-installer.js
@@ -63,6 +63,7 @@ function installAndroidSdk(apiLevel, target, arch, channelId, emulatorBuild, ndk
             // add paths for commandline-tools and platform-tools
             core.addPath(`${cmdlineToolsPath}/latest:${cmdlineToolsPath}/latest/bin:${process.env.ANDROID_HOME}/platform-tools`);
             // set standard AVD path
+            yield io.mkdirP(`${process.env.HOME}/.android/avd`);
             core.exportVariable('ANDROID_AVD_HOME', `${process.env.HOME}/.android/avd`);
             // accept all Android SDK licenses
             yield exec.exec(`sh -c \\"yes | sdkmanager --licenses > /dev/null"`);

--- a/src/sdk-installer.ts
+++ b/src/sdk-installer.ts
@@ -32,6 +32,7 @@ export async function installAndroidSdk(apiLevel: string, target: string, arch: 
     core.addPath(`${cmdlineToolsPath}/latest:${cmdlineToolsPath}/latest/bin:${process.env.ANDROID_HOME}/platform-tools`);
 
     // set standard AVD path
+    await io.mkdirP(`${process.env.HOME}/.android/avd`);
     core.exportVariable('ANDROID_AVD_HOME', `${process.env.HOME}/.android/avd`);
 
     // accept all Android SDK licenses


### PR DESCRIPTION
Fixes https://github.com/ReactiveCircus/android-emulator-runner/issues/400

Re-land https://github.com/ReactiveCircus/android-emulator-runner/pull/409 which was reverted in https://github.com/ReactiveCircus/android-emulator-runner/pull/414, as the avd cache generated after the initial fix made me think the change wasn't needed anymore because it works without it. The fix is indeed required as the action currently still fails without restoring the any avd cache that restores the now missing `avd` dir in ubuntu-24.04.