### PR TITLE
Correct ram-size parameter examples: remove 'M' suffix to show proper format

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ jobs:
 | `arch` | Optional | `x86` | CPU architecture of the system image - `x86`, `x86_64` or `arm64-v8a`. Note that `x86_64` image is only available for API 21+. `arm64-v8a` images require Android 4.2+ and are limited to fewer API levels (e.g. 30). |
 | `profile` | Optional | N/A | Hardware profile used for creating the AVD - e.g. `Nexus 6`. For a list of all profiles available, run `avdmanager list device`. |
 | `cores` | Optional | 2 | Number of cores to use for the emulator (`hw.cpu.ncore` in config.ini). |
-| `ram-size` | Optional | N/A | Size of RAM to use for this AVD, in KB or MB, denoted with K or M. - e.g. `2048M` |
+| `ram-size` | Optional | N/A | Size of RAM to use for this AVD, in KB or MB, denoted with K or M. - e.g. `2048` |
 | `heap-size` | Optional | N/A | Heap size to use for this AVD, in KB or MB, denoted with K or M. - e.g. `512M` |
 | `sdcard-path-or-size` | Optional | N/A | Path to the SD card image for this AVD or the size of a new SD card image to create for this AVD, in KB or MB, denoted with K or M. - e.g. `path/to/sdcard`, or `1000M`. |
 | `disk-size` | Optional | N/A | Disk size, or partition size to use for this AVD. Either in bytes or KB, MB or GB, when denoted with K, M or G. - e.g. `2048M` |

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: 'the number of cores to use for the emulator'
     default: 2
   ram-size:
-    description: 'size of RAM to use for this AVD, in KB or MB, denoted with K or M. - e.g. `2048M`'
+    description: 'size of RAM to use for this AVD, in KB or MB, denoted with K or M. - e.g. `2048`'
   heap-size:
     description: 'size of heap to use for this AVD in MB. - e.g. `512M`'
   sdcard-path-or-size:


### PR DESCRIPTION
This PR corrects the documentation for the `ram-size` parameter in both the README.md and action.yml files by updating the example format.

## Problem
The `ram-size` parameter documentation showed an inconsistent example format:
- Example: `e.g. 2048M`
- Description: "in KB or MB, denoted with K or M"

This suggested users should include the unit suffix in the parameter value, but the correct format expects just the numeric value.

## Solution
Updated the examples in both files:
- **README.md**: Changed `e.g. 2048M` to `e.g. 2048`
- **action.yml**: Changed `e.g. 2048M` to `e.g. 2048`

The descriptive text about "denoted with K or M" remains unchanged to help users understand the unit notation, while the examples now show the correct parameter format that the action expects.
