### PR TITLE
docs: update AVD profile description

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           arch: x86_64
-          profile: Nexus 6
+          profile: pixel_7_pro
           script: ./gradlew connectedCheck
 ```
 
@@ -208,7 +208,7 @@ jobs:
 | `system-image-api-level` | Optional | same as `api-level` | API level of the system image - e.g. `34-ext10`, `35-ext15`. |
 | `target` | Optional | `default` | Target of the system image - e.g. `default`, `google_apis`, `google_apis_ps16k`, `google_apis_playstore`, `google_apis_playstore_ps16k`, `android-wear`, `android-wear-cn`, `android-tv`, `google-tv`, `aosp_atd`, `google_atd`, `android-automotive`, `android-automotive-playstore`, `android-desktop`. Please run `sdkmanager --list` to see the available targets. |
 | `arch` | Optional | `x86` | CPU architecture of the system image - `x86`, `x86_64` or `arm64-v8a`. Note that `x86_64` image is only available for API 21+. `arm64-v8a` images require Android 4.2+ and are limited to fewer API levels (e.g. 30). |
-| `profile` | Optional | N/A | Hardware profile used for creating the AVD - e.g. `Nexus 6`. For a list of all profiles available, run `avdmanager list device`. |
+| `profile` | Optional | N/A | Hardware profile id used for creating the AVD - e.g. `pixel_7_pro`. For a list of all profiles available, run `avdmanager list device`. |
 | `cores` | Optional | 2 | Number of cores to use for the emulator (`hw.cpu.ncore` in config.ini). |
 | `ram-size` | Optional | N/A | Size of RAM to use for this AVD, in KB or MB, denoted with K or M. - e.g. `2048M` |
 | `heap-size` | Optional | N/A | Heap size to use for this AVD, in KB or MB, denoted with K or M. - e.g. `512M` |


### PR DESCRIPTION
the previous description was ambiguous;

The required parameter is the `id`, not the `name` of the device. For old devices the values are the same, but for new ones they are not and so from the readme, you can't tell if name or id should be used, or if this matters at all (it does matter).


snippet from my `avdmanager list device`

```
---------
id: 22 or "Nexus 9"
    Name: Nexus 9
    OEM : Google
---------
id: 23 or "Nexus One"
    Name: Nexus One
    OEM : Google
---------
id: 24 or "Nexus S"
    Name: Nexus S
    OEM : Google
---------
id: 25 or "pixel"
    Name: Pixel
    OEM : Google
---------
id: 26 or "pixel_2"
    Name: Pixel 2
    OEM : Google
---------
id: 27 or "pixel_2_xl"
    Name: Pixel 2 XL
    OEM : Google
```