### PR TITLE
fix: remove problematic / unneeded `--abi` option in avd creation

### DIFF
--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -48,7 +48,7 @@ function createAvd(arch, avdName, cores, diskSize, enableHardwareKeyboard, force
                 const profileOption = profile.trim() !== '' ? `--device '${profile}'` : '';
                 const sdcardPathOrSizeOption = sdcardPathOrSize.trim() !== '' ? `--sdcard '${sdcardPathOrSize}'` : '';
                 console.log(`Creating AVD.`);
-                yield exec.exec(`sh -c \\"echo no | avdmanager create avd --force -n "${avdName}" --abi '${target}/${arch}' --package 'system-images;android-${systemImageApiLevel};${target};${arch}' ${profileOption} ${sdcardPathOrSizeOption}"`);
+                yield exec.exec(`sh -c \\"echo no | avdmanager create avd --force -n "${avdName}" --package 'system-images;android-${systemImageApiLevel};${target};${arch}' ${profileOption} ${sdcardPathOrSizeOption}"`);
             }
             if (cores || ramSize || heapSize || enableHardwareKeyboard || diskSize) {
                 const configEntries = [];

--- a/src/emulator-manager.ts
+++ b/src/emulator-manager.ts
@@ -27,7 +27,7 @@ export async function createAvd(
       const sdcardPathOrSizeOption = sdcardPathOrSize.trim() !== '' ? `--sdcard '${sdcardPathOrSize}'` : '';
       console.log(`Creating AVD.`);
       await exec.exec(
-        `sh -c \\"echo no | avdmanager create avd --force -n "${avdName}" --abi '${target}/${arch}' --package 'system-images;android-${systemImageApiLevel};${target};${arch}' ${profileOption} ${sdcardPathOrSizeOption}"`
+        `sh -c \\"echo no | avdmanager create avd --force -n "${avdName}" --package 'system-images;android-${systemImageApiLevel};${target};${arch}' ${profileOption} ${sdcardPathOrSizeOption}"`
       );
     }
 


### PR DESCRIPTION
Including this breaks the creation of the new ps16kb emulators:

https://github.com/ankidroid/Anki-Android/actions/runs/19682207445/job/56378738665#step:11:82

```

  /usr/bin/sh -c \echo no | avdmanager create avd --force -n test --abi 'google_apis_ps16k/x86_64' --package 'system-images;android-36;google_apis_ps16k;x86_64'  --sdcard '100M'
  Loading local repository...                                                     
  [=========                              ] 25% Loading local repository...       
  [=========                              ] 25% Fetch remote repository...        
  [=======================================] 100% Fetch remote repository...       
  Error: Invalid --tag google_apis_ps16k for the selected package. Valid tags are:
  page_size_16kb
  null
```

Removing this in my testing breaks nothing and results in emulator creation that has the correct tag still (visible via inspection with `avdmanager list avds`)

I tested by pulling the newest armeabi-v7 a image (API25 emulator) while on an arm64-v8a machine (apple silicon mac) to see what would happen.

1- unable to create an avd with abi that uses arm64-v8a but the armeabi-v7a image
2- able to create an avd with abi that uses armeabi-v7 and the armeabi-v7a image
3 same abi tag was used via autoselection when I used *no* abi option and the same image

that tells me that even on a platform where there may be multiple choices (armeabi-v7a image and arm64e host, should be able to use both abis), it auto-selected what the code was doing anyway.

So this should not represent a breaking change or loss of functionality for anyone. 

But it will definitely fix the installation and use of 16kb page size images since they were only failing during the avd creation because of an incompatible abi generated in this action. Generating the correct abi option via a conditional here in the code is possible, but removing the option when it seems useless appears to be a cleaner way forward in my opnion