### PR TITLE
Build tools 37.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Update SDK build tools to `37.0.0`. - [#475](https://github.com/ReactiveCircus/android-emulator-runner/pull/475)
+
 ## v2.37.0
 
 * Update SDK build tools to `36.0.0`, update SDK command-line tools to `20.0`. - [#467](https://github.com/ReactiveCircus/android-emulator-runner/pull/467)

--- a/lib/sdk-installer.js
+++ b/lib/sdk-installer.js
@@ -39,7 +39,7 @@ const exec = __importStar(require("@actions/exec"));
 const io = __importStar(require("@actions/io"));
 const tc = __importStar(require("@actions/tool-cache"));
 const fs = __importStar(require("fs"));
-const BUILD_TOOLS_VERSION = '36.0.0';
+const BUILD_TOOLS_VERSION = '37.0.0';
 // SDK command-line tools 20.0
 const CMDLINE_TOOLS_URL_MAC = 'https://dl.google.com/android/repository/commandlinetools-mac-14742923_latest.zip';
 const CMDLINE_TOOLS_URL_LINUX = 'https://dl.google.com/android/repository/commandlinetools-linux-14742923_latest.zip';

--- a/src/sdk-installer.ts
+++ b/src/sdk-installer.ts
@@ -4,7 +4,7 @@ import * as io from '@actions/io';
 import * as tc from '@actions/tool-cache';
 import * as fs from 'fs';
 
-const BUILD_TOOLS_VERSION = '36.0.0';
+const BUILD_TOOLS_VERSION = '37.0.0';
 // SDK command-line tools 20.0
 const CMDLINE_TOOLS_URL_MAC = 'https://dl.google.com/android/repository/commandlinetools-mac-14742923_latest.zip';
 const CMDLINE_TOOLS_URL_LINUX = 'https://dl.google.com/android/repository/commandlinetools-linux-14742923_latest.zip';

--- a/test-fixture/app/build.gradle.kts
+++ b/test-fixture/app/build.gradle.kts
@@ -4,13 +4,13 @@ plugins {
 
 android {
     namespace = "com.example.testapp"
-    compileSdk = 36
-    buildToolsVersion = "36.0.0"
+    compileSdk = 37
+    buildToolsVersion = "37.0.0"
 
     defaultConfig {
         applicationId = "com.example.testapp"
         minSdk = 23
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0"
 


### PR DESCRIPTION
Fixes https://github.com/ReactiveCircus/android-emulator-runner/issues/474, based on https://github.com/ReactiveCircus/android-emulator-runner/pull/467.