### PR TITLE
Fix `heap-size` writing unrecognized `hw.heapSize` property

### DIFF
--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -61,7 +61,7 @@ async function createAvd(arch, avdName, cores, diskSize, enableHardwareKeyboard,
                 configEntries.push(`hw.ramSize=${ramSize}`);
             }
             if (heapSize) {
-                configEntries.push(`hw.heapSize=${heapSize}`);
+                configEntries.push(`vm.heapSize=${heapSize}`);
             }
             if (enableHardwareKeyboard) {
                 configEntries.push('hw.keyboard=yes');

--- a/src/emulator-manager.ts
+++ b/src/emulator-manager.ts
@@ -41,7 +41,7 @@ export async function createAvd(
         configEntries.push(`hw.ramSize=${ramSize}`);
       }
       if (heapSize) {
-        configEntries.push(`hw.heapSize=${heapSize}`);
+        configEntries.push(`vm.heapSize=${heapSize}`);
       }
       if (enableHardwareKeyboard) {
         configEntries.push('hw.keyboard=yes');


### PR DESCRIPTION
## Problem

The `heap-size` input is written to the AVD's `config.ini` as `hw.heapSize`:

```ts
if (heapSize) {
  configEntries.push(`hw.heapSize=${heapSize}`);
}
```

`hw.heapSize` is not a recognized AVD hardware property, so the value is
ignored and `heap-size` has no effect on the emulator.

The property that actually sets the per-app VM heap is `vm.heapSize`, as
defined in the SDK's `emulator/lib/hardware-properties.ini`:

```
name        = vm.heapSize
type        = integer
abstract    = Max VM application heap size
description = The maximum heap size a Dalvik application might allocate
              before being killed by the system. Value is in megabytes.
```

## Fix

Write `vm.heapSize` instead of `hw.heapSize`. `hw.ramSize` (used for the
`ram-size` input) is already the correct property name and is left unchanged.

Related: #188

## Notes

- Only `src/emulator-manager.ts` and the compiled `lib/emulator-manager.js`
  change, matching the repo convention of committing both.
- The change is a single token inside a template literal, so the compiled
  output is identical to `tsc`'s.
