### PR TITLE
Add emulator startup retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ jobs:
 | `avd-name` | Optional | `test` | Custom AVD name used for creating the Android Virtual Device. |
 | `force-avd-creation` | Optional | `true` | Whether to force create the AVD by overwriting an existing AVD with the same name as `avd-name` - `true` or `false`. |
 | `emulator-boot-timeout` | Optional | `600` | Emulator boot timeout in seconds. If it takes longer to boot, the action would fail - e.g. `300` for 5 minutes. |
+| `emulator-startup-retries` | Optional | `0` | Number of times to retry emulator startup before running `script`. This retries emulator launch, boot and readiness checks, but does not retry `script` after it has started. |
 | `emulator-port` | Optional | `5554` | Emulator port to use. Allows to run this action on multiple workers on a single machine at the same time. This input is available for the script as `EMULATOR_PORT` enviromental variable. This port is automatically used by android device related tasks in gradle |
 | `emulator-options` | Optional | See below | Command-line options used when launching the emulator (replacing all default options) - e.g. `-no-window -no-snapshot -camera-back emulated`. |
 | `disable-animations` | Optional | `true` | Whether to disable animations - `true` or `false`. |

--- a/__tests__/input-validator.test.ts
+++ b/__tests__/input-validator.test.ts
@@ -213,6 +213,32 @@ describe('emulator-build validator tests', () => {
   });
 });
 
+describe('emulator-startup-retries validator tests', () => {
+  it('Throws if emulator-startup-retries is negative', () => {
+    const func = () => {
+      validator.checkEmulatorStartupRetries(-1);
+    };
+    expect(func).toThrowError(`Emulator startup retries must be a non-negative integer, was -1`);
+  });
+
+  it('Throws if emulator-startup-retries is not an integer', () => {
+    const func = () => {
+      validator.checkEmulatorStartupRetries(1.5);
+    };
+    expect(func).toThrowError(`Emulator startup retries must be a non-negative integer, was 1.5`);
+  });
+
+  it('Validates successfully if emulator-startup-retries is a non-negative integer', () => {
+    expect(() => {
+      validator.checkEmulatorStartupRetries(0);
+    }).not.toThrow();
+
+    expect(() => {
+      validator.checkEmulatorStartupRetries(1);
+    }).not.toThrow();
+  });
+});
+
 describe('checkDiskSize validator tests', () => {
   it('Empty size is acceptable, means default', () => {
     const func = () => {

--- a/action-types.yml
+++ b/action-types.yml
@@ -42,6 +42,8 @@ inputs:
    type: boolean
   emulator-boot-timeout:
    type: integer
+  emulator-startup-retries:
+   type: integer
   emulator-port:
     type: integer
   emulator-options:

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,9 @@ inputs:
   emulator-boot-timeout:
     description: 'Emulator boot timeout in seconds. If it takes longer to boot, the action would fail - e.g. `300` for 5 minutes'
     default: '600'
+  emulator-startup-retries:
+    description: 'Number of times to retry emulator startup before running the script. This retries emulator launch, boot and readiness checks, but not the script itself.'
+    default: '0'
   emulator-port:
     description: 'Port to run emulator on, allows to run multiple emulators on the same physical machine'
     default: '5554'

--- a/lib/emulator-manager.js
+++ b/lib/emulator-manager.js
@@ -82,7 +82,7 @@ async function createAvd(arch, avdName, cores, diskSize, enableHardwareKeyboard,
 /**
  * Launches an existing AVD instance with the specified configurations.
  */
-async function launchEmulator(avdName, disableAnimations, disableLinuxHardwareAcceleration, disableSpellChecker, emulatorBootTimeout, emulatorOptions, enableHardwareKeyboard, port) {
+async function launchEmulator(avdName, disableAnimations, disableLinuxHardwareAcceleration, disableSpellChecker, emulatorBootTimeout, emulatorOptions, emulatorStartupRetries, enableHardwareKeyboard, port) {
     try {
         console.log(`::group::Launch Emulator`);
         // turn off hardware acceleration on Linux
@@ -90,35 +90,74 @@ async function launchEmulator(avdName, disableAnimations, disableLinuxHardwareAc
             console.log('Disabling Linux hardware acceleration.');
             emulatorOptions += ' -accel off';
         }
-        // start emulator
-        console.log('Starting emulator.');
-        await exec.exec(`sh -c \\"${process.env.ANDROID_HOME}/emulator/emulator -port ${port} -avd "${avdName}" ${emulatorOptions} &"`, [], {
-            listeners: {
-                stderr: (data) => {
-                    if (data.toString().includes('invalid command-line parameter')) {
-                        throw new Error(data.toString());
-                    }
-                },
-            },
-        });
-        // wait for emulator to complete booting
-        await waitForDevice(port, emulatorBootTimeout);
-        await adb(port, `shell input keyevent 82`);
-        if (disableAnimations) {
-            console.log('Disabling animations.');
-            await adb(port, `shell settings put global window_animation_scale 0.0`);
-            await adb(port, `shell settings put global transition_animation_scale 0.0`);
-            await adb(port, `shell settings put global animator_duration_scale 0.0`);
-        }
-        if (disableSpellChecker) {
-            await adb(port, `shell settings put secure spell_checker_enabled 0`);
-        }
-        if (enableHardwareKeyboard) {
-            await adb(port, `shell settings put secure show_ime_with_hard_keyboard 0`);
+        for (let attempt = 0; attempt <= emulatorStartupRetries; attempt++) {
+            try {
+                if (emulatorStartupRetries > 0) {
+                    console.log(`Emulator startup attempt ${attempt + 1} of ${emulatorStartupRetries + 1}.`);
+                }
+                // start emulator
+                console.log('Starting emulator.');
+                await exec.exec(`sh -c \\"${process.env.ANDROID_HOME}/emulator/emulator -port ${port} -avd "${avdName}" ${emulatorOptions} &"`, [], {
+                    listeners: {
+                        stderr: (data) => {
+                            if (data.toString().includes('invalid command-line parameter')) {
+                                throw new Error(data.toString());
+                            }
+                        },
+                    },
+                });
+                // wait for emulator to complete booting and accept console commands
+                await waitForDevice(port, emulatorBootTimeout);
+                await waitForEmulatorConsole(port);
+                await adb(port, `shell input keyevent 82`);
+                if (disableAnimations) {
+                    console.log('Disabling animations.');
+                    await adb(port, `shell settings put global window_animation_scale 0.0`);
+                    await adb(port, `shell settings put global transition_animation_scale 0.0`);
+                    await adb(port, `shell settings put global animator_duration_scale 0.0`);
+                }
+                if (disableSpellChecker) {
+                    await adb(port, `shell settings put secure spell_checker_enabled 0`);
+                }
+                if (enableHardwareKeyboard) {
+                    await adb(port, `shell settings put secure show_ime_with_hard_keyboard 0`);
+                }
+                return;
+            }
+            catch (error) {
+                if (attempt >= emulatorStartupRetries || isInvalidCommandLineParameterError(error)) {
+                    throw error;
+                }
+                console.warn(error instanceof Error ? error.message : error);
+                console.warn(`Emulator startup failed. Retrying.`);
+                await killEmulator(port);
+                await delay(5000);
+            }
         }
     }
     finally {
         console.log(`::endgroup::`);
+    }
+}
+function isInvalidCommandLineParameterError(error) {
+    return error instanceof Error && error.message.includes('invalid command-line parameter');
+}
+async function waitForEmulatorConsole(port) {
+    const retryInterval = 2;
+    const maxAttempts = 15;
+    for (let attempt = 0; attempt <= maxAttempts; attempt++) {
+        try {
+            await adb(port, `emu avd name`);
+            console.log('Emulator console ready.');
+            return;
+        }
+        catch (error) {
+            if (attempt >= maxAttempts) {
+                throw new Error(`Timeout waiting for emulator console.`);
+            }
+            console.warn(error instanceof Error ? error.message : error);
+            await delay(retryInterval * 1000);
+        }
     }
 }
 /**

--- a/lib/input-validator.js
+++ b/lib/input-validator.js
@@ -11,6 +11,7 @@ exports.checkDisableSpellchecker = checkDisableSpellchecker;
 exports.checkDisableLinuxHardwareAcceleration = checkDisableLinuxHardwareAcceleration;
 exports.checkEnableHardwareKeyboard = checkEnableHardwareKeyboard;
 exports.checkEmulatorBuild = checkEmulatorBuild;
+exports.checkEmulatorStartupRetries = checkEmulatorStartupRetries;
 exports.checkDiskSize = checkDiskSize;
 exports.MIN_API_LEVEL = 15;
 exports.VALID_ARCHS = ['x86', 'x86_64', 'arm64-v8a'];
@@ -72,6 +73,11 @@ function checkEnableHardwareKeyboard(enableHardwareKeyboard) {
 function checkEmulatorBuild(emulatorBuild) {
     if (isNaN(Number(emulatorBuild)) || !Number.isInteger(Number(emulatorBuild))) {
         throw new Error(`Unexpected emulator build: '${emulatorBuild}'.`);
+    }
+}
+function checkEmulatorStartupRetries(emulatorStartupRetries) {
+    if (emulatorStartupRetries < 0 || !Number.isInteger(emulatorStartupRetries)) {
+        throw new Error(`Emulator startup retries must be a non-negative integer, was ${emulatorStartupRetries}`);
     }
 }
 function isValidBoolean(value) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -105,6 +105,10 @@ async function run() {
         // Emulator boot timeout seconds
         const emulatorBootTimeout = parseInt(core.getInput('emulator-boot-timeout'), 10);
         console.log(`Emulator boot timeout: ${emulatorBootTimeout}`);
+        // Emulator startup retries
+        const emulatorStartupRetries = parseInt(core.getInput('emulator-startup-retries'), 10);
+        (0, input_validator_1.checkEmulatorStartupRetries)(emulatorStartupRetries);
+        console.log(`Emulator startup retries: ${emulatorStartupRetries}`);
         // Emulator port to use
         port = parseInt(core.getInput('emulator-port'), 10);
         (0, input_validator_1.checkPort)(port);
@@ -202,7 +206,7 @@ async function run() {
             console.log(`::endgroup::`);
         }
         // launch an emulator
-        await (0, emulator_manager_1.launchEmulator)(avdName, disableAnimations, disableLinuxHardwareAcceleration, disableSpellchecker, emulatorBootTimeout, emulatorOptions, enableHardwareKeyboard, port);
+        await (0, emulator_manager_1.launchEmulator)(avdName, disableAnimations, disableLinuxHardwareAcceleration, disableSpellchecker, emulatorBootTimeout, emulatorOptions, emulatorStartupRetries, enableHardwareKeyboard, port);
         // execute the custom script
         try {
             // move to custom working directory if set

--- a/src/emulator-manager.ts
+++ b/src/emulator-manager.ts
@@ -70,6 +70,7 @@ export async function launchEmulator(
   disableSpellChecker: boolean,
   emulatorBootTimeout: number,
   emulatorOptions: string,
+  emulatorStartupRetries: number,
   enableHardwareKeyboard: boolean,
   port: number,
 ): Promise<void> {
@@ -82,37 +83,79 @@ export async function launchEmulator(
       emulatorOptions += ' -accel off';
     }
 
-    // start emulator
-    console.log('Starting emulator.');
+    for (let attempt = 0; attempt <= emulatorStartupRetries; attempt++) {
+      try {
+        if (emulatorStartupRetries > 0) {
+          console.log(`Emulator startup attempt ${attempt + 1} of ${emulatorStartupRetries + 1}.`);
+        }
 
-    await exec.exec(`sh -c \\"${process.env.ANDROID_HOME}/emulator/emulator -port ${port} -avd "${avdName}" ${emulatorOptions} &"`, [], {
-      listeners: {
-        stderr: (data: Buffer) => {
-          if (data.toString().includes('invalid command-line parameter')) {
-            throw new Error(data.toString());
-          }
-        },
-      },
-    });
+        // start emulator
+        console.log('Starting emulator.');
 
-    // wait for emulator to complete booting
-    await waitForDevice(port, emulatorBootTimeout);
-    await adb(port, `shell input keyevent 82`);
+        await exec.exec(`sh -c \\"${process.env.ANDROID_HOME}/emulator/emulator -port ${port} -avd "${avdName}" ${emulatorOptions} &"`, [], {
+          listeners: {
+            stderr: (data: Buffer) => {
+              if (data.toString().includes('invalid command-line parameter')) {
+                throw new Error(data.toString());
+              }
+            },
+          },
+        });
 
-    if (disableAnimations) {
-      console.log('Disabling animations.');
-      await adb(port, `shell settings put global window_animation_scale 0.0`);
-      await adb(port, `shell settings put global transition_animation_scale 0.0`);
-      await adb(port, `shell settings put global animator_duration_scale 0.0`);
-    }
-    if (disableSpellChecker) {
-      await adb(port, `shell settings put secure spell_checker_enabled 0`);
-    }
-    if (enableHardwareKeyboard) {
-      await adb(port, `shell settings put secure show_ime_with_hard_keyboard 0`);
+        // wait for emulator to complete booting and accept console commands
+        await waitForDevice(port, emulatorBootTimeout);
+        await waitForEmulatorConsole(port);
+        await adb(port, `shell input keyevent 82`);
+
+        if (disableAnimations) {
+          console.log('Disabling animations.');
+          await adb(port, `shell settings put global window_animation_scale 0.0`);
+          await adb(port, `shell settings put global transition_animation_scale 0.0`);
+          await adb(port, `shell settings put global animator_duration_scale 0.0`);
+        }
+        if (disableSpellChecker) {
+          await adb(port, `shell settings put secure spell_checker_enabled 0`);
+        }
+        if (enableHardwareKeyboard) {
+          await adb(port, `shell settings put secure show_ime_with_hard_keyboard 0`);
+        }
+        return;
+      } catch (error) {
+        if (attempt >= emulatorStartupRetries || isInvalidCommandLineParameterError(error)) {
+          throw error;
+        }
+
+        console.warn(error instanceof Error ? error.message : error);
+        console.warn(`Emulator startup failed. Retrying.`);
+        await killEmulator(port);
+        await delay(5000);
+      }
     }
   } finally {
     console.log(`::endgroup::`);
+  }
+}
+
+function isInvalidCommandLineParameterError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes('invalid command-line parameter');
+}
+
+async function waitForEmulatorConsole(port: number): Promise<void> {
+  const retryInterval = 2;
+  const maxAttempts = 15;
+  for (let attempt = 0; attempt <= maxAttempts; attempt++) {
+    try {
+      await adb(port, `emu avd name`);
+      console.log('Emulator console ready.');
+      return;
+    } catch (error) {
+      if (attempt >= maxAttempts) {
+        throw new Error(`Timeout waiting for emulator console.`);
+      }
+
+      console.warn(error instanceof Error ? error.message : error);
+      await delay(retryInterval * 1000);
+    }
   }
 }
 

--- a/src/input-validator.ts
+++ b/src/input-validator.ts
@@ -69,6 +69,12 @@ export function checkEmulatorBuild(emulatorBuild: string): void {
   }
 }
 
+export function checkEmulatorStartupRetries(emulatorStartupRetries: number): void {
+  if (emulatorStartupRetries < 0 || !Number.isInteger(emulatorStartupRetries)) {
+    throw new Error(`Emulator startup retries must be a non-negative integer, was ${emulatorStartupRetries}`);
+  }
+}
+
 function isValidBoolean(value: string): boolean {
   return value === 'true' || value === 'false';
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {
   checkChannel,
   checkEnableHardwareKeyboard,
   checkDiskSize,
+  checkEmulatorStartupRetries,
   checkPort,
   playstoreTargetSubstitution,
   MIN_PORT,
@@ -97,6 +98,11 @@ async function run() {
     // Emulator boot timeout seconds
     const emulatorBootTimeout = parseInt(core.getInput('emulator-boot-timeout'), 10);
     console.log(`Emulator boot timeout: ${emulatorBootTimeout}`);
+
+    // Emulator startup retries
+    const emulatorStartupRetries = parseInt(core.getInput('emulator-startup-retries'), 10);
+    checkEmulatorStartupRetries(emulatorStartupRetries);
+    console.log(`Emulator startup retries: ${emulatorStartupRetries}`);
 
     // Emulator port to use
     port = parseInt(core.getInput('emulator-port'), 10);
@@ -210,7 +216,17 @@ async function run() {
     }
 
     // launch an emulator
-    await launchEmulator(avdName, disableAnimations, disableLinuxHardwareAcceleration, disableSpellchecker, emulatorBootTimeout, emulatorOptions, enableHardwareKeyboard, port);
+    await launchEmulator(
+      avdName,
+      disableAnimations,
+      disableLinuxHardwareAcceleration,
+      disableSpellchecker,
+      emulatorBootTimeout,
+      emulatorOptions,
+      emulatorStartupRetries,
+      enableHardwareKeyboard,
+      port,
+    );
 
     // execute the custom script
     try {


### PR DESCRIPTION
Retry emulator launch and readiness checks before running the user script. This adds a console readiness probe so startup can fail before Gradle or other Android tooling attempts to use an emulator that is not ready.

```yaml
- uses: reactivecircus/android-emulator-runner@v2
  with:
    # ...
    emulator-boot-timeout: 1200
    emulator-startup-retries: 1
```

Handling this inside the action keeps GitHub Actions workflows simple. Without this, callers need to duplicate the emulator step and add conditional glue steps to decide when to rerun it. The action already owns emulator launch, boot polling, and cleanup, so it can retry the flaky startup phase with less workflow noise and without rerunning user scripts after they have started.